### PR TITLE
Tests: add `void` return type hints

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,12 +9,6 @@ parameters:
     # To be addressed in follow-up commits
     ignoreErrors:
         -
-            message: '#Method [a-zA-Z\\]+?Test::test[a-zA-Z_]+\(\) has no return type specified\.#'
-            identifier: missingType.return
-            count: 22
-            path: tests/*
-
-        -
             message: '#^Function file_to_doc_constants\(\) has no return type specified\.$#'
             identifier: missingType.return
             count: 1

--- a/tests/MetaData/Functions/FunctionMetaDataTest.php
+++ b/tests/MetaData/Functions/FunctionMetaDataTest.php
@@ -17,7 +17,7 @@ use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 
 class FunctionMetaDataTest extends TestCase
 {
-    public function test_basic_from_reflection_data()
+    public function test_basic_from_reflection_data(): void
     {
         $stub = <<<'STUB'
 <?php
@@ -44,7 +44,7 @@ STUB;
         self::assertCount(3, $fn->parameters);
     }
 
-    public function test_is_deprecated_from_reflection_data()
+    public function test_is_deprecated_from_reflection_data(): void
     {
         $stub = <<<'STUB'
 <?php

--- a/tests/MetaData/Functions/ParameterMetaDataTest.php
+++ b/tests/MetaData/Functions/ParameterMetaDataTest.php
@@ -18,7 +18,7 @@ use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 
 class ParameterMetaDataTest extends TestCase
 {
-    public function test_optional_from_reflection_data()
+    public function test_optional_from_reflection_data(): void
     {
         $stub = <<<'STUB'
 <?php
@@ -58,7 +58,7 @@ STUB;
         self::assertTrue($expectedDefaultValue->isSame($param->defaultValue));
     }
 
-    public function test_variadic_from_reflection_data()
+    public function test_variadic_from_reflection_data(): void
     {
         $stub = <<<'STUB'
 <?php
@@ -87,7 +87,7 @@ STUB;
         self::assertNull($param->defaultValue);
     }
 
-    public function test_by_ref_from_reflection_data()
+    public function test_by_ref_from_reflection_data(): void
     {
         $stub = <<<'STUB'
 <?php
@@ -112,7 +112,7 @@ STUB;
         self::assertNull($param->defaultValue);
     }
 
-    public function test_with_attribute_from_reflection_data()
+    public function test_with_attribute_from_reflection_data(): void
     {
         $stub = <<<'STUB'
 <?php
@@ -141,7 +141,7 @@ STUB;
         self::assertTrue((new AttributeMetaData('\\SensitiveParameter'))->isSame($param->attributes[0]));
     }
 
-    public function test_default_values_const_expr_from_reflection_data()
+    public function test_default_values_const_expr_from_reflection_data(): void
     {
         $stub = <<<'STUB'
 <?php
@@ -199,7 +199,7 @@ STUB;
         self::assertSame('SomeClass::CONST', $params[11]->defaultValue->value);
     }
 
-    public function test_default_values_bitwise_expr_from_reflection_data()
+    public function test_default_values_bitwise_expr_from_reflection_data(): void
     {
         $stub = <<<'STUB'
 <?php
@@ -227,7 +227,7 @@ STUB;
         self::assertSame('FLAG_A|FLAG_B|FLAG_C', $params[1]->defaultValue->value);
     }
 
-    public function test_default_values_function_call_expr_from_reflection_data()
+    public function test_default_values_function_call_expr_from_reflection_data(): void
     {
         $stub = <<<'STUB'
 <?php

--- a/tests/MetaData/InitializerTest.php
+++ b/tests/MetaData/InitializerTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class InitializerTest extends TestCase
 {
-    public function test_initializer_is_same()
+    public function test_initializer_is_same(): void
     {
         $constant = new Initializer(InitializerVariant::Constant, 'SOME_CONST');
         self::assertTrue($constant->isSame($constant));
@@ -22,7 +22,7 @@ class InitializerTest extends TestCase
         self::assertFalse($literal->isSame($constant));
     }
 
-    public function test_constant_doc_parsing()
+    public function test_constant_doc_parsing(): void
     {
         $xml = '<initializer><constant>SOME_CONST</constant></initializer>';
 
@@ -33,7 +33,7 @@ class InitializerTest extends TestCase
         self::assertSame('SOME_CONST', $initializer->value);
     }
 
-    public function test_literal_int_doc_parsing()
+    public function test_literal_int_doc_parsing(): void
     {
         $xml = '<initializer><literal>1</literal></initializer>';
 
@@ -44,7 +44,7 @@ class InitializerTest extends TestCase
         self::assertSame('1', $initializer->value);
     }
 
-    public function test_text_int_doc_parsing()
+    public function test_text_int_doc_parsing(): void
     {
         $xml = '<initializer>1</initializer>';
 
@@ -55,7 +55,7 @@ class InitializerTest extends TestCase
         self::assertSame('1', $initializer->value);
     }
 
-    public function test_text_empty_array_doc_parsing()
+    public function test_text_empty_array_doc_parsing(): void
     {
         $xml = '<initializer>[]</initializer>';
 
@@ -66,7 +66,7 @@ class InitializerTest extends TestCase
         self::assertSame('[]', $initializer->value);
     }
 
-    public function test_text_string_doc_parsing()
+    public function test_text_string_doc_parsing(): void
     {
         $xml = '<initializer>"\t"</initializer>';
 
@@ -78,7 +78,7 @@ class InitializerTest extends TestCase
     }
 
     /** This is taken from htmlspecialchars() */
-    public function test_text_bitmask_doc_parsing()
+    public function test_text_bitmask_doc_parsing(): void
     {
         $xml = '<initializer>ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401</initializer>';
 
@@ -90,7 +90,7 @@ class InitializerTest extends TestCase
     }
 
     /** This is taken from reference/stomp/stomp/construct.xml */
-    public function test_text_function_doc_parsing()
+    public function test_text_function_doc_parsing(): void
     {
         $xml = '<initializer>ini_get("stomp.default_broker_uri")</initializer>';
 
@@ -101,7 +101,7 @@ class InitializerTest extends TestCase
         self::assertSame('ini_get("stomp.default_broker_uri")', $initializer->value);
     }
 
-    public function test_text_bad_constant_doc_parsing()
+    public function test_text_bad_constant_doc_parsing(): void
     {
         $xml = '<initializer>PDO::PARAM_STR</initializer>';
 
@@ -112,7 +112,7 @@ class InitializerTest extends TestCase
         self::assertSame('PDO::PARAM_STR', $initializer->value);
     }
 
-    public function test_from_int_scalar_node()
+    public function test_from_int_scalar_node(): void
     {
         $node = Int_::fromString('25');
         $initializer = Initializer::fromPhpParserExpr($node);
@@ -135,7 +135,7 @@ class InitializerTest extends TestCase
         self::assertSame('0b1101', $initializer->value);
     }
 
-    public function test_from_float_scalar_node()
+    public function test_from_float_scalar_node(): void
     {
         $node = Float_::fromString('12.5');
         $initializer = Initializer::fromPhpParserExpr($node);
@@ -148,7 +148,7 @@ class InitializerTest extends TestCase
         self::assertSame('2.4578e12', $initializer->value);
     }
 
-    public function test_from_string_scalar_node()
+    public function test_from_string_scalar_node(): void
     {
         $node = String_::fromString('"This is a simple string"');
         $initializer = Initializer::fromPhpParserExpr($node);

--- a/tests/MetaData/Lists/ConstantListTest.php
+++ b/tests/MetaData/Lists/ConstantListTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConstantListTest extends TestCase
 {
-    public function test_to_xml_varlistentry_list()
+    public function test_to_xml_varlistentry_list(): void
     {
         $document = XMLDocument::createEmpty();
         $constants = [


### PR DESCRIPTION
Removes 22 phpstan errors that were previously ignored