### PR TITLE
parse-stub: document `file_to_doc_constants()`, handle failure cases

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,24 +9,6 @@ parameters:
     # To be addressed in follow-up commits
     ignoreErrors:
         -
-            message: '#^Function file_to_doc_constants\(\) has no return type specified\.$#'
-            identifier: missingType.return
-            count: 1
-            path: scripts/parse-stub.php
-
-        -
-            message: '#^Only iterables can be unpacked, list\<string\>\|false given\.$#'
-            identifier: arrayUnpacking.nonIterable
-            count: 2
-            path: scripts/parse-stub.php
-
-        -
-            message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|false given\.$#'
-            identifier: argument.type
-            count: 1
-            path: scripts/parse-stub.php
-
-        -
             message: '#^Only iterables can be unpacked, list\<string\>\|false given\.$#'
             identifier: arrayUnpacking.nonIterable
             count: 2

--- a/scripts/parse-stub.php
+++ b/scripts/parse-stub.php
@@ -3,13 +3,21 @@
 use Dom\XMLDocument;
 use Girgias\StubToDocbook\Differ\ConstantListDiffer;
 use Girgias\StubToDocbook\Documentation\DocumentedConstantParser;
+use Girgias\StubToDocbook\MetaData\ConstantMetaData;
 use Girgias\StubToDocbook\MetaData\Lists\ConstantList;
 use Girgias\StubToDocbook\Reports\ConstantDocumentationReport;
 
 $totalDocConst = 0;
-function file_to_doc_constants(string $path)
+/**
+ * @return array<string, ConstantMetaData>
+ */
+function file_to_doc_constants(string $path): array
 {
     $content = file_get_contents($path);
+    if ($content === false) {
+        // This shouldn't happen unless there is a race condition
+        throw new Exception("Missing content for $path");
+    }
     $content = str_replace(
         [
             '&true;',
@@ -60,8 +68,8 @@ $doc_constants_files = [
     $doc_en_repo . 'appendices/reserved.constants.core.xml',
     // TODO Handle properly the table parsing
     $doc_en_repo . 'appendices/tokens.xml',
-    ...glob($doc_en_repo . 'reference/*/constants.xml'),
-    ...glob($doc_en_repo . 'reference/*/constants_*.xml'),
+    ...(glob($doc_en_repo . 'reference/*/constants.xml') ?: []),
+    ...(glob($doc_en_repo . 'reference/*/constants_*.xml') ?: []),
 ];
 
 $doc_constants = array_diff($doc_constants_files, $IGNORE_DOC_CONSTANT_FILES);


### PR DESCRIPTION
In case `file_get_contents()` or `glob()` return false, have a reasonable fallback. This also removes 4 phpstan errors that were previously ignored.