### PR TITLE
Implement basic stub differ for functions and use it in migration diff script

### DIFF
--- a/src/Differ/FunctionListDiffer.php
+++ b/src/Differ/FunctionListDiffer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Girgias\StubToDocbook\Differ;
+
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
+
+final class FunctionListDiffer
+{
+    /**
+     * @param array<string, FunctionMetaData> $baseVersion
+     * @param array<string, FunctionMetaData> $newVersion
+     * TODO: Function Signature differences between existing functions
+     */
+    public static function stubDiff(array $baseVersion, array $newVersion): FunctionStubMapDiff
+    {
+        $newSymbols = array_diff_key($newVersion, $baseVersion);
+
+        $removedSymbols = array_diff_key($baseVersion, $newVersion);
+
+        $baseDeprecated = array_filter($baseVersion, symbol_is_deprecated(...));
+        $newDeprecated = array_filter($newVersion, symbol_is_deprecated(...));
+        $newDeprecationsSymbols = array_diff_key($newDeprecated, $baseDeprecated);
+
+
+        return new FunctionStubMapDiff(
+            $newSymbols,
+            $removedSymbols,
+            $newDeprecationsSymbols,
+        );
+    }
+}

--- a/src/Differ/FunctionStubMapDiff.php
+++ b/src/Differ/FunctionStubMapDiff.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Girgias\StubToDocbook\Differ;
+
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
+
+final class FunctionStubMapDiff
+{
+    /**
+     * @param array<string, FunctionMetaData> $new
+     * @param array<string, FunctionMetaData> $removed
+     * @param array<string, FunctionMetaData> $deprecated
+     */
+    public function __construct(
+        readonly array $new,
+        readonly array $removed,
+        readonly array $deprecated,
+    ) {}
+}

--- a/src/utils.php
+++ b/src/utils.php
@@ -1,5 +1,6 @@
 <?php
 
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionClass;
@@ -22,4 +23,28 @@ function get_extension_name_from_reflection_date(
 function symbol_is_deprecated(object $symbol): bool
 {
     return $symbol->isDeprecated;
+}
+
+/**
+ * @template T of object{name: string}
+ * @param list<T> $list
+ * @return array<string, T>
+ */
+function named_symbol_list_to_map(array $list): array {
+
+    $names = array_map(fn($fn) => $fn->name, $list);
+    return array_combine($names, $list);
+}
+
+/**
+ * @param list<ReflectionFunction> $list
+ * @return array<string, FunctionMetaData>
+ */
+function from_better_reflection_list_to_metadata(array $list): array
+{
+    $fns = array_map(
+        FunctionMetaData::fromReflectionData(...),
+        $list,
+    );
+    return named_symbol_list_to_map($fns);
 }

--- a/tests/Differ/FunctionListDifferTest.php
+++ b/tests/Differ/FunctionListDifferTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Differ;
+
+use Girgias\StubToDocbook\Differ\FunctionListDiffer;
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
+use Girgias\StubToDocbook\Stubs\ZendEngineReflector;
+use Girgias\StubToDocbook\Tests\ZendEngineStringSourceLocator;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\BetterReflection;
+
+class FunctionListDifferTest extends TestCase
+{
+
+    const string BASE_STUB_FILE_STR = <<<'STUB'
+<?php
+
+/** @generate-class-entries */
+
+function no_change(int $a, int $b): bool {}
+
+function signature_change(int $aa): bool {}
+
+function will_be_removed(): void {}
+
+/**
+ * @return array<string, int|string>|false
+ * @refcount 1
+ */
+#[\Deprecated(since: '8.2', message: 'existing dep message')]
+function strptime(string $timestamp, string $format): array|false {}
+
+/**
+ * @param resource $stream
+ */
+function will_be_deprecated($stream, int $seconds, int $microseconds = 0): bool {}
+STUB;
+    const string NEW_STUB_FILE_STR = <<<'STUB'
+<?php
+
+/** @generate-class-entries */
+
+function no_change(int $a, int $b): bool {}
+
+function signature_change(int $aa, ?string $new_param = null): bool {}
+
+/**
+ * @return array<string, int|string>|false
+ * @refcount 1
+ */
+#[\Deprecated(since: '8.2', message: 'existing dep message')]
+function strptime(string $timestamp, string $format): array|false {}
+
+/**
+ * @param resource $stream
+ */
+#[\Deprecated(since: '8.5', message: "new deprecation message")]
+function will_be_deprecated($stream, int $seconds, int $microseconds = 0): bool {}
+
+function new_function(int $a, int $b): bool {}
+STUB;
+
+    public function test_diff_between_two_stub_files(): void
+    {
+        $astLocator = (new BetterReflection())->astLocator();
+
+        $baseReflector = ZendEngineReflector::newZendEngineReflector([
+            new ZendEngineStringSourceLocator(self::BASE_STUB_FILE_STR, $astLocator),
+        ]);
+        $baseSymbols = from_better_reflection_list_to_metadata($baseReflector->reflectAllFunctions());
+
+        $newReflector = ZendEngineReflector::newZendEngineReflector([
+            new ZendEngineStringSourceLocator(self::NEW_STUB_FILE_STR, $astLocator),
+        ]);
+        $newSymbols = from_better_reflection_list_to_metadata($newReflector->reflectAllFunctions());
+
+        $diff = FunctionListDiffer::stubDiff($baseSymbols, $newSymbols);
+        self::assertCount(1, $diff->new);
+        self::assertArrayHasKey('new_function', $diff->new);
+        self::assertSame('new_function', $diff->new['new_function']->name);
+
+        self::assertCount(1, $diff->removed);
+        self::assertArrayHasKey('will_be_removed', $diff->removed);
+        self::assertSame('will_be_removed', $diff->removed['will_be_removed']->name);
+
+        self::assertCount(1, $diff->deprecated);
+        self::assertArrayHasKey('will_be_deprecated', $diff->deprecated);
+        self::assertSame('will_be_deprecated', $diff->deprecated['will_be_deprecated']->name);
+    }
+}


### PR DESCRIPTION
Output of `php scripts/migration-diff.php` is now:

```
Total 8.4 constants parsed = 3114; functions parsed = 2245
Total 8.5 constants parsed = 3155; functions parsed = 2261
New constants:42
	Extension: Core
		ZEND_VM_KIND
	Extension: Curl
		CURLOPT_INFILESIZE_LARGE
		CURLFOLLOW_ALL
		CURLFOLLOW_OBEYCODE
		CURLFOLLOW_FIRSTONLY
		CURLINFO_HTTPAUTH_USED
		CURLINFO_PROXYAUTH_USED
		CURLINFO_QUEUE_TIME_T
		CURLINFO_USED_PROXY
		CURLINFO_CONN_ID
		CURLOPT_SSL_SIGNATURE_ALGORITHMS
	Extension: Filter
		FILTER_THROW_ON_FAILURE
	Extension: Openssl
		PKCS7_NOSMIMECAP
		PKCS7_CRLFEOL
		PKCS7_NOCRL
		PKCS7_NO_DUAL_CONTENT
		OPENSSL_PKCS1_PSS_PADDING
	Extension: PHP (main/)
		PHP_BUILD_DATE
		PHP_BUILD_PROVIDER
	Extension: Posix
		POSIX_SC_OPEN_MAX
	Extension: Sockets
		AF_PACKET
		SO_BUSY_POLL
		TCP_FUNCTION_BLK
		TCP_FUNCTION_ALIAS
		TCP_REUSPORT_LB_NUMA
		TCP_REUSPORT_LB_NUMA_NODOM
		TCP_REUSPORT_LB_NUMA_CURDOM
		TCP_BBR_ALGORITHM
		IPPROTO_ICMP
		IPPROTO_ICMPV6
		IP_BINDANY
		ETH_P_IP
		ETH_P_IPV6
		ETH_P_LOOP
		ETH_P_ALL
		UDP_SEGMENT
		SHUT_RD
		SHUT_WR
		SHUT_RDWR
	Extension: Standard
		IMAGETYPE_HEIF
	Extension: Tokenizer
		T_VOID_CAST
		T_PIPE
Newly deprecated constants:4
	Extension: Date
		DATE_RFC7231
	Extension: Ldap
		GSLC_SSL_NO_AUTH
		GSLC_SSL_ONEWAY_AUTH
		GSLC_SSL_TWOWAY_AUTH
Removed constants:1
	Extension: Openssl
		OPENSSL_ALGO_DSS1
New functions:16
	Extension: Core
		clone
		get_error_handler
		get_exception_handler
	Extension: Curl
		curl_multi_get_handles
		curl_share_init_persistent
	Extension: Enchant
		enchant_dict_remove
		enchant_dict_remove_from_session
	Extension: Intl
		grapheme_levenshtein
		locale_is_right_to_left
		locale_add_likely_subtags
		locale_minimize_subtags
	Extension: Opcache
		opcache_is_script_cached_in_file_cache
	Extension: Pgsql
		pg_service
		pg_close_stmt
	Extension: Standard
		array_first
		array_last
Newly deprecated functions:8
	Extension: Curl
		curl_close
		curl_share_close
	Extension: Fileinfo
		finfo_close
	Extension: Gd
		imagedestroy
	Extension: Ldap
		ldap_connect_wallet
	Extension: Mysqli
		mysqli_execute
	Extension: Standard
		socket_set_timeout
	Extension: Xml
		xml_parser_free
Removed functions:0
```
