### PR TITLE
Add functions to migration diff script

### DIFF
--- a/scripts/migration-diff.php
+++ b/scripts/migration-diff.php
@@ -2,30 +2,38 @@
 
 use Girgias\StubToDocbook\Differ\ConstantListDiffer;
 use Girgias\StubToDocbook\Differ\ConstantStubListDiff;
+use Girgias\StubToDocbook\Differ\FunctionListDiffer;
+use Girgias\StubToDocbook\Differ\FunctionStubMapDiff;
 use Girgias\StubToDocbook\MetaData\ConstantMetaData;
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
 use Girgias\StubToDocbook\MetaData\Lists\ConstantList;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 require_once 'stub-utils.php';
 
-/** @return array<string, list<ConstantMetaData>> */
-function list_to_extensions_list(ConstantList $constantList): array
+/**
+ * @template T of object{name: string, extension: string}
+ * @param array<string, T> $symbols
+ * @return array<string, array<string, T>>
+ */
+function symbol_list_to_extensions_map(array $symbols): array
 {
     $extensions = [];
-    foreach ($constantList->constants as $constant) {
-        $extensions[$constant->extension][] = $constant;
+    foreach ($symbols as $name => $symbol) {
+        $extensions[$symbol->extension][$name] = $symbol;
     }
+    // TODO: Need to sort such that 'core' (regardless of capitalization) is first entry.
     ksort($extensions, SORT_NATURAL | SORT_FLAG_CASE);
     return $extensions;
 }
 
-/** @param array<string, list<ConstantMetaData>> $constantList */
-function print_extensions_list_of_constants(array $constantList): void
+/** @param array<string, array<string, ConstantMetaData>|array<string, FunctionMetaData>> $symbolsMap */
+function print_extensions_map_of_symbols(array $symbolsMap): void
 {
-    foreach ($constantList as $extension => $constants) {
+    foreach ($symbolsMap as $extension => $symbols) {
         echo "\tExtension: {$extension}\n";
-        foreach ($constants as $constant) {
-            echo "\t\t{$constant->name} with type {$constant->type->toXml()}\n";
+        foreach ($symbols as $symbol) {
+            echo "\t\t{$symbol->name}\n";
         }
     }
 }
@@ -33,11 +41,20 @@ function print_extensions_list_of_constants(array $constantList): void
 function print_constant_list_diff(ConstantStubListDiff $diff): void
 {
     echo 'New constants:' . count($diff->new) . "\n";
-    print_extensions_list_of_constants(list_to_extensions_list($diff->new));
+    print_extensions_map_of_symbols(symbol_list_to_extensions_map($diff->new->constants));
     echo 'Newly deprecated constants:' . count($diff->deprecated) . "\n";
-    print_extensions_list_of_constants(list_to_extensions_list($diff->deprecated));
+    print_extensions_map_of_symbols(symbol_list_to_extensions_map($diff->deprecated->constants));
     echo 'Removed constants:' . count($diff->removed) . "\n";
-    print_extensions_list_of_constants(list_to_extensions_list($diff->removed));
+    print_extensions_map_of_symbols(symbol_list_to_extensions_map($diff->removed->constants));
+}
+
+function print_function_map_diff(FunctionStubMapDiff $diff): void {
+    echo 'New functions:' . count($diff->new) . "\n";
+    print_extensions_map_of_symbols(symbol_list_to_extensions_map($diff->new));
+    echo 'Newly deprecated functions:' . count($diff->deprecated) . "\n";
+    print_extensions_map_of_symbols(symbol_list_to_extensions_map($diff->deprecated));
+    echo 'Removed functions:' . count($diff->removed) . "\n";
+    print_extensions_map_of_symbols(symbol_list_to_extensions_map($diff->removed));
 }
 
 // Use array_merge_recursive with functions, classes, and constants for deprecations/BC breaks pages
@@ -47,13 +64,17 @@ $master_dir = dirname(__DIR__, 2) . '/PHP-8.5/';
 
 $prior_version_reflector = get_reflector($prior_version_dir);
 $prior_version_constants = ConstantList::fromReflectionDataArray($prior_version_reflector->reflectAllConstants(), IGNORED_CONSTANTS);
+$prior_version_functions = from_better_reflection_list_to_metadata($prior_version_reflector->reflectAllFunctions());
 
 $master_reflector = get_reflector($master_dir);
 $master_constants = ConstantList::fromReflectionDataArray($master_reflector->reflectAllConstants(), IGNORED_CONSTANTS);
+$master_functions = from_better_reflection_list_to_metadata($master_reflector->reflectAllFunctions());
 
-$diff = ConstantListDiffer::stubDiff($prior_version_constants, $master_constants);
+$diffC = ConstantListDiffer::stubDiff($prior_version_constants, $master_constants);
+$diffF = FunctionListDiffer::stubDiff($prior_version_functions, $master_functions);
 
-echo "Total 8.4 constants parsed = ", count($prior_version_constants), "\n";
-echo "Total 8.5 constants parsed = ", count($master_constants), "\n";
+echo "Total 8.4 constants parsed = ", count($prior_version_constants), "; functions parsed = ", count($prior_version_functions), "\n";
+echo "Total 8.5 constants parsed = ", count($master_constants), "; functions parsed = ", count($master_functions), "\n";
 
-print_constant_list_diff($diff);
+print_constant_list_diff($diffC);
+print_function_map_diff($diffF);


### PR DESCRIPTION
`php scripts/migration-diff.php` now outputs a diff between 8.4 and 8.5 for functions:

```
Total 8.4 constants parsed = 3114; functions parsed = 2245
Total 8.5 constants parsed = 3155; functions parsed = 2261
New constants:42
	Extension: Core
		ZEND_VM_KIND
	Extension: Curl
		CURLOPT_INFILESIZE_LARGE
		CURLFOLLOW_ALL
		CURLFOLLOW_OBEYCODE
		CURLFOLLOW_FIRSTONLY
		CURLINFO_HTTPAUTH_USED
		CURLINFO_PROXYAUTH_USED
		CURLINFO_QUEUE_TIME_T
		CURLINFO_USED_PROXY
		CURLINFO_CONN_ID
		CURLOPT_SSL_SIGNATURE_ALGORITHMS
	Extension: Filter
		FILTER_THROW_ON_FAILURE
	Extension: Openssl
		PKCS7_NOSMIMECAP
		PKCS7_CRLFEOL
		PKCS7_NOCRL
		PKCS7_NO_DUAL_CONTENT
		OPENSSL_PKCS1_PSS_PADDING
	Extension: PHP (main/)
		PHP_BUILD_DATE
		PHP_BUILD_PROVIDER
	Extension: Posix
		POSIX_SC_OPEN_MAX
	Extension: Sockets
		AF_PACKET
		SO_BUSY_POLL
		TCP_FUNCTION_BLK
		TCP_FUNCTION_ALIAS
		TCP_REUSPORT_LB_NUMA
		TCP_REUSPORT_LB_NUMA_NODOM
		TCP_REUSPORT_LB_NUMA_CURDOM
		TCP_BBR_ALGORITHM
		IPPROTO_ICMP
		IPPROTO_ICMPV6
		IP_BINDANY
		ETH_P_IP
		ETH_P_IPV6
		ETH_P_LOOP
		ETH_P_ALL
		UDP_SEGMENT
		SHUT_RD
		SHUT_WR
		SHUT_RDWR
	Extension: Standard
		IMAGETYPE_HEIF
	Extension: Tokenizer
		T_VOID_CAST
		T_PIPE
Newly deprecated constants:4
	Extension: Date
		DATE_RFC7231
	Extension: Ldap
		GSLC_SSL_NO_AUTH
		GSLC_SSL_ONEWAY_AUTH
		GSLC_SSL_TWOWAY_AUTH
Removed constants:1
	Extension: Openssl
		OPENSSL_ALGO_DSS1
New functions:16
	Extension: Core
		clone
		get_error_handler
		get_exception_handler
	Extension: Curl
		curl_multi_get_handles
		curl_share_init_persistent
	Extension: Enchant
		enchant_dict_remove
		enchant_dict_remove_from_session
	Extension: Intl
		grapheme_levenshtein
		locale_is_right_to_left
		locale_add_likely_subtags
		locale_minimize_subtags
	Extension: Opcache
		opcache_is_script_cached_in_file_cache
	Extension: Pgsql
		pg_service
		pg_close_stmt
	Extension: Standard
		array_first
		array_last
Newly deprecated functions:8
	Extension: Curl
		curl_close
		curl_share_close
	Extension: Fileinfo
		finfo_close
	Extension: Gd
		imagedestroy
	Extension: Ldap
		ldap_connect_wallet
	Extension: Mysqli
		mysqli_execute
	Extension: Standard
		socket_set_timeout
	Extension: Xml
		xml_parser_free
Removed functions:0
```