### PR TITLE
Add PropertyMetaData documentation parsing (parseFromDoc)

### DIFF
--- a/src/MetaData/Classes/PropertyMetaData.php
+++ b/src/MetaData/Classes/PropertyMetaData.php
@@ -80,14 +80,14 @@ final class PropertyMetaData
                 'type' => $type = DocumentedTypeParser::parse($node),
                 'varname' => $name = $node->textContent,
                 'initializer' => $defaultValue = Initializer::parseFromDoc($node),
-                'info', 'synopsisinfo', 'templatename' =>
-                    throw new \Exception('"' . $tagName . '" child tag for <fieldsynopsis> is not supported'),
+                'info', 'synopsisinfo', 'templatename'
+                    => throw new \Exception('"' . $tagName . '" child tag for <fieldsynopsis> is not supported'),
             };
         }
 
         $deprecatedAttributes = array_filter(
             $attributes,
-            fn(AttributeMetaData $attr) => $attr->name === '\Deprecated',
+            fn (AttributeMetaData $attr) => $attr->name === '\Deprecated',
         );
         $isDeprecated = count($deprecatedAttributes) === 1;
 
@@ -111,7 +111,7 @@ final class PropertyMetaData
         bool &$isStatic,
         bool &$isReadOnly,
         Visibility &$visibility,
-        array &$attributes
+        array &$attributes,
     ): void {
         match ($element->textContent) {
             'public' => $visibility = Visibility::Public,

--- a/src/MetaData/Classes/PropertyMetaData.php
+++ b/src/MetaData/Classes/PropertyMetaData.php
@@ -2,9 +2,12 @@
 
 namespace Girgias\StubToDocbook\MetaData\Classes;
 
+use Dom\Element;
+use Dom\Text;
 use Girgias\StubToDocbook\MetaData\AttributeMetaData;
 use Girgias\StubToDocbook\MetaData\Initializer;
 use Girgias\StubToDocbook\MetaData\Visibility;
+use Girgias\StubToDocbook\Types\DocumentedTypeParser;
 use Girgias\StubToDocbook\Types\ReflectionTypeParser;
 use Girgias\StubToDocbook\Types\Type;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
@@ -26,6 +29,56 @@ final class PropertyMetaData
         readonly bool $isDeprecated = false,
     ) {}
 
+
+    /**
+     * DocBook 5.2 <fieldsynopsis> documentation
+     * URL: https://tdg.docbook.org/tdg/5.2/fieldsynopsis
+     */
+    public static function parseFromDoc(Element $element): self
+    {
+        if ($element->tagName !== 'fieldsynopsis') {
+            throw new \Exception('Unexpected tag "' . $element->tagName . '"');
+        }
+
+        $name = null;
+        $type = null;
+        $defaultValue = null;
+        $visibility = Visibility::Public;
+        $isStatic = false;
+        $isReadOnly = false;
+
+        foreach ($element->childNodes as $node) {
+            if ($node instanceof Text) {
+                continue;
+            }
+            if (($node instanceof Element) === false) {
+                throw new \Exception("Unexpected node type: " . $node::class);
+            }
+            match ($node->tagName) {
+                'modifier' => match ($node->textContent) {
+                    'public' => $visibility = Visibility::Public,
+                    'protected' => $visibility = Visibility::Protected,
+                    'private' => $visibility = Visibility::Private,
+                    'static' => $isStatic = true,
+                    'readonly' => $isReadOnly = true,
+                    default => null,
+                },
+                'type' => $type = DocumentedTypeParser::parse($node),
+                'varname' => $name = $node->textContent,
+                'initializer' => $defaultValue = Initializer::parseFromDoc($node),
+                default => throw new \Exception('Unexpected <fieldsynopsis> child tag: <' . $node->tagName . '>'),
+            };
+        }
+
+        return new self(
+            $name,
+            $type,
+            defaultValue: $defaultValue,
+            visibility: $visibility,
+            isReadOnly: $isReadOnly,
+            isStatic: $isStatic,
+        );
+    }
 
     public static function fromReflectionData(ReflectionProperty $reflectionData): self
     {


### PR DESCRIPTION
## Summary
- Add `parseFromDoc()` static method to `PropertyMetaData`
- Parses DocBook `<fieldsynopsis>` elements
- Handles type, visibility, readonly, static, and initializer/default value
- 4 new tests covering basic, protected/readonly, initializer, and static properties

Closes #59
Closes #28