### PR TITLE
Implement exclusion list for symbols

### DIFF
--- a/src/ExclusionList.php
+++ b/src/ExclusionList.php
@@ -69,7 +69,7 @@ final class ExclusionList
     {
         return array_filter(
             $symbols,
-            fn(string $name) => !$excludeCheck($name),
+            fn (string $name) => !$excludeCheck($name),
             ARRAY_FILTER_USE_KEY,
         );
     }

--- a/src/ExclusionList.php
+++ b/src/ExclusionList.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Girgias\StubToDocbook;
+
+final class ExclusionList
+{
+    /**
+     * @param list<string> $constantNames Exact constant names to exclude
+     * @param list<string> $functionNames Exact function names to exclude
+     * @param list<string> $classNames Exact class names to exclude
+     * @param list<string> $stubFiles Stub file paths to exclude
+     * @param list<string> $docFiles Documentation file paths to exclude
+     * @param list<string> $namePatterns Regex patterns to match symbol names to exclude
+     */
+    public function __construct(
+        readonly array $constantNames = [],
+        readonly array $functionNames = [],
+        readonly array $classNames = [],
+        readonly array $stubFiles = [],
+        readonly array $docFiles = [],
+        readonly array $namePatterns = [],
+    ) {}
+
+    public function isConstantExcluded(string $name): bool
+    {
+        return in_array($name, $this->constantNames, true)
+            || $this->matchesPattern($name);
+    }
+
+    public function isFunctionExcluded(string $name): bool
+    {
+        return in_array($name, $this->functionNames, true)
+            || $this->matchesPattern($name);
+    }
+
+    public function isClassExcluded(string $name): bool
+    {
+        return in_array($name, $this->classNames, true)
+            || $this->matchesPattern($name);
+    }
+
+    public function isStubFileExcluded(string $path): bool
+    {
+        foreach ($this->stubFiles as $excluded) {
+            if (str_ends_with($path, $excluded)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function isDocFileExcluded(string $path): bool
+    {
+        foreach ($this->docFiles as $excluded) {
+            if (str_ends_with($path, $excluded)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @template T
+     * @param array<string, T> $symbols
+     * @param callable(string): bool $excludeCheck
+     * @return array<string, T>
+     */
+    public static function filterMap(array $symbols, callable $excludeCheck): array
+    {
+        return array_filter(
+            $symbols,
+            fn(string $name) => !$excludeCheck($name),
+            ARRAY_FILTER_USE_KEY,
+        );
+    }
+
+    private function matchesPattern(string $name): bool
+    {
+        foreach ($this->namePatterns as $pattern) {
+            if (preg_match($pattern, $name) === 1) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/ExclusionListTest.php
+++ b/tests/ExclusionListTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Girgias\StubToDocbook\Tests;
+
+use Girgias\StubToDocbook\ExclusionList;
+use PHPUnit\Framework\TestCase;
+
+class ExclusionListTest extends TestCase
+{
+    public function test_empty_exclusion_list_excludes_nothing(): void
+    {
+        $list = new ExclusionList();
+
+        self::assertFalse($list->isConstantExcluded('FOO'));
+        self::assertFalse($list->isFunctionExcluded('bar'));
+        self::assertFalse($list->isClassExcluded('Baz'));
+    }
+
+    public function test_constant_exclusion(): void
+    {
+        $list = new ExclusionList(constantNames: ['ZEND_DEBUG', 'SOME_CONST']);
+
+        self::assertTrue($list->isConstantExcluded('ZEND_DEBUG'));
+        self::assertTrue($list->isConstantExcluded('SOME_CONST'));
+        self::assertFalse($list->isConstantExcluded('OTHER'));
+    }
+
+    public function test_function_exclusion(): void
+    {
+        $list = new ExclusionList(functionNames: ['zend_test_func']);
+
+        self::assertTrue($list->isFunctionExcluded('zend_test_func'));
+        self::assertFalse($list->isFunctionExcluded('array_map'));
+    }
+
+    public function test_class_exclusion(): void
+    {
+        $list = new ExclusionList(classNames: ['ZendTestClass']);
+
+        self::assertTrue($list->isClassExcluded('ZendTestClass'));
+        self::assertFalse($list->isClassExcluded('stdClass'));
+    }
+
+    public function test_stub_file_exclusion(): void
+    {
+        $list = new ExclusionList(stubFiles: ['ext/zend_test/test.stub.php']);
+
+        self::assertTrue($list->isStubFileExcluded('/path/to/php-src/ext/zend_test/test.stub.php'));
+        self::assertFalse($list->isStubFileExcluded('/path/to/php-src/ext/standard/basic.stub.php'));
+    }
+
+    public function test_pattern_exclusion(): void
+    {
+        $list = new ExclusionList(namePatterns: ['/^MYSQLI_SERVER_/']);
+
+        self::assertTrue($list->isConstantExcluded('MYSQLI_SERVER_QUERY_NO_INDEX_USED'));
+        self::assertTrue($list->isFunctionExcluded('MYSQLI_SERVER_SOMETHING'));
+        self::assertFalse($list->isConstantExcluded('MYSQLI_CLIENT_FLAG'));
+    }
+
+    public function test_filter_map(): void
+    {
+        $list = new ExclusionList(constantNames: ['BAD']);
+        $symbols = ['GOOD' => 1, 'BAD' => 2, 'OK' => 3];
+
+        $filtered = ExclusionList::filterMap($symbols, $list->isConstantExcluded(...));
+
+        self::assertArrayHasKey('GOOD', $filtered);
+        self::assertArrayNotHasKey('BAD', $filtered);
+        self::assertArrayHasKey('OK', $filtered);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ExclusionList` class supporting exclusion by exact name, file path suffix, and regex patterns
- Separate exclusion for constants, functions, classes, stub files, and doc files
- `filterMap()` helper for applying exclusions to symbol maps
- 7 tests covering all exclusion types

Closes #51