### PR TITLE
Generalize SymbolListDiffer to support class and enum version diffs

### DIFF
--- a/scripts/migration-diff.php
+++ b/scripts/migration-diff.php
@@ -66,7 +66,9 @@ $master_reflector = get_reflector($master_dir);
 $master_constants = ConstantList::fromReflectionDataArray($master_reflector->reflectAllConstants(), IGNORED_CONSTANTS);
 $master_functions = from_better_reflection_list_to_metadata(FunctionMetaData::class, $master_reflector->reflectAllFunctions());
 
+/** @var SymbolStubMapDiff<ConstantMetaData> $diffC */
 $diffC = SymbolListDiffer::stubDiff($prior_version_constants->constants, $master_constants->constants);
+/** @var SymbolStubMapDiff<FunctionMetaData> $diffF */
 $diffF = SymbolListDiffer::stubDiff($prior_version_functions, $master_functions);
 
 echo "Total 8.4 constants parsed = ", count($prior_version_constants), "; functions parsed = ", count($prior_version_functions), "\n";

--- a/src/Differ/SymbolListDiffer.php
+++ b/src/Differ/SymbolListDiffer.php
@@ -2,11 +2,8 @@
 
 namespace Girgias\StubToDocbook\Differ;
 
-use Girgias\StubToDocbook\MetaData\ConstantMetaData;
-use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
-
 /**
- * @template T of FunctionMetaData|ConstantMetaData
+ * @template T of object{name: string, isDeprecated: bool}
  */
 final class SymbolListDiffer
 {

--- a/src/Differ/SymbolStubMapDiff.php
+++ b/src/Differ/SymbolStubMapDiff.php
@@ -2,11 +2,8 @@
 
 namespace Girgias\StubToDocbook\Differ;
 
-use Girgias\StubToDocbook\MetaData\ConstantMetaData;
-use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
-
 /**
- * @template T of FunctionMetaData|ConstantMetaData
+ * @template T of object{name: string, isDeprecated: bool}
  */
 final class SymbolStubMapDiff
 {


### PR DESCRIPTION
## Summary
- Widen `SymbolListDiffer` and `SymbolStubMapDiff` template constraint from `FunctionMetaData|ConstantMetaData` to `object{name: string, isDeprecated: bool}`
- This enables using the existing differ infrastructure for class and enum diffs between PHP versions
- No behavioral change for existing constant and function diffs

Closes #34
Closes #35