### PR TITLE
Generate missing constants documentation

### DIFF
--- a/src/Generator/MissingConstantsGenerator.php
+++ b/src/Generator/MissingConstantsGenerator.php
@@ -21,7 +21,9 @@ final class MissingConstantsGenerator
         $document->append($element);
         $document->formatOutput = true;
 
-        return $document->saveXml($element);
+        $xml = $document->saveXml($element);
+        assert($xml !== false);
+        return $xml;
     }
 
     /**

--- a/src/Generator/MissingConstantsGenerator.php
+++ b/src/Generator/MissingConstantsGenerator.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Girgias\StubToDocbook\Generator;
+
+use Dom\XMLDocument;
+use Girgias\StubToDocbook\MetaData\Lists\ConstantList;
+
+final class MissingConstantsGenerator
+{
+    /**
+     * Generate DocBook XML string for a list of missing constants.
+     */
+    public static function generate(ConstantList $missingConstants): string
+    {
+        if (count($missingConstants) === 0) {
+            return '';
+        }
+
+        $document = XMLDocument::createEmpty();
+        $element = $missingConstants->toXml($document, 0);
+        $document->append($element);
+        $document->formatOutput = true;
+
+        return $document->saveXml($element);
+    }
+
+    /**
+     * Generate DocBook XML grouped by extension.
+     * @return array<string, string> Extension name => XML string
+     */
+    public static function generateByExtension(ConstantList $missingConstants): array
+    {
+        $byExtension = [];
+        foreach ($missingConstants->constants as $constant) {
+            $byExtension[$constant->extension][$constant->name] = $constant;
+        }
+
+        $result = [];
+        foreach ($byExtension as $extension => $constants) {
+            $list = new ConstantList($constants);
+            $result[$extension] = self::generate($list);
+        }
+
+        return $result;
+    }
+}

--- a/tests/Generator/MissingConstantsGeneratorTest.php
+++ b/tests/Generator/MissingConstantsGeneratorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Girgias\StubToDocbook\Tests\Generator;
+
+use Girgias\StubToDocbook\Generator\MissingConstantsGenerator;
+use Girgias\StubToDocbook\MetaData\ConstantMetaData;
+use Girgias\StubToDocbook\MetaData\Lists\ConstantList;
+use Girgias\StubToDocbook\Types\SingleType;
+use PHPUnit\Framework\TestCase;
+
+class MissingConstantsGeneratorTest extends TestCase
+{
+    public function test_empty_list_returns_empty_string(): void
+    {
+        $list = new ConstantList([]);
+        self::assertSame('', MissingConstantsGenerator::generate($list));
+    }
+
+    public function test_generates_variablelist_xml(): void
+    {
+        $list = new ConstantList([
+            'MY_CONST' => new ConstantMetaData(
+                'MY_CONST',
+                new SingleType('int'),
+                'ext_test',
+                null,
+                value: 42,
+            ),
+        ]);
+
+        $xml = MissingConstantsGenerator::generate($list);
+
+        self::assertStringContainsString('<variablelist>', $xml);
+        self::assertStringContainsString('<constant>MY_CONST</constant>', $xml);
+        self::assertStringContainsString('<type>int</type>', $xml);
+    }
+
+    public function test_generates_by_extension(): void
+    {
+        $list = new ConstantList([
+            'EXT_A_CONST' => new ConstantMetaData('EXT_A_CONST', new SingleType('int'), 'ext_a', null),
+            'EXT_B_CONST' => new ConstantMetaData('EXT_B_CONST', new SingleType('string'), 'ext_b', null),
+            'EXT_A_OTHER' => new ConstantMetaData('EXT_A_OTHER', new SingleType('bool'), 'ext_a', null),
+        ]);
+
+        $result = MissingConstantsGenerator::generateByExtension($list);
+
+        self::assertCount(2, $result);
+        self::assertArrayHasKey('ext_a', $result);
+        self::assertArrayHasKey('ext_b', $result);
+        self::assertStringContainsString('EXT_A_CONST', $result['ext_a']);
+        self::assertStringContainsString('EXT_A_OTHER', $result['ext_a']);
+        self::assertStringContainsString('EXT_B_CONST', $result['ext_b']);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MissingConstantsGenerator` class
- `generate()` produces DocBook `<variablelist>` XML for missing constants
- `generateByExtension()` groups output by extension name
- 3 tests

Closes #37