### PR TITLE
Generate missing functions documentation

### DIFF
--- a/src/Generator/MissingFunctionsGenerator.php
+++ b/src/Generator/MissingFunctionsGenerator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Girgias\StubToDocbook\Generator;
+
+use Dom\XMLDocument;
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
+
+final class MissingFunctionsGenerator
+{
+    /**
+     * Generate DocBook XML for a single missing function.
+     */
+    public static function generateOne(FunctionMetaData $function): string
+    {
+        $document = XMLDocument::createEmpty();
+        $element = $function->toMethodSynopsisXml($document);
+        $document->append($element);
+        $document->formatOutput = true;
+
+        return $document->saveXml($element);
+    }
+
+    /**
+     * Generate DocBook XML for multiple missing functions grouped by extension.
+     * @param array<string, FunctionMetaData> $functions
+     * @return array<string, list<string>> Extension name => list of XML strings
+     */
+    public static function generateByExtension(array $functions): array
+    {
+        $result = [];
+        foreach ($functions as $function) {
+            $result[$function->extension][] = self::generateOne($function);
+        }
+        return $result;
+    }
+}

--- a/src/Generator/MissingFunctionsGenerator.php
+++ b/src/Generator/MissingFunctionsGenerator.php
@@ -17,7 +17,9 @@ final class MissingFunctionsGenerator
         $document->append($element);
         $document->formatOutput = true;
 
-        return $document->saveXml($element);
+        $xml = $document->saveXml($element);
+        assert(is_string($xml));
+        return $xml;
     }
 
     /**

--- a/src/MetaData/Functions/FunctionMetaData.php
+++ b/src/MetaData/Functions/FunctionMetaData.php
@@ -207,7 +207,10 @@ final readonly class FunctionMetaData implements Equatable
         }
         if ($this->visibility !== Visibility::Public) {
             $modifier = $document->createElement('modifier');
-            $modifier->textContent = $this->visibility->value;
+            $modifier->textContent = match ($this->visibility) {
+                Visibility::Protected => 'protected',
+                Visibility::Private => 'private',
+            };
             $methodsynopsis->append($modifier);
         }
         if ($this->isStatic) {

--- a/tests/Generator/MissingFunctionsGeneratorTest.php
+++ b/tests/Generator/MissingFunctionsGeneratorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Girgias\StubToDocbook\Tests\Generator;
+
+use Girgias\StubToDocbook\Generator\MissingFunctionsGenerator;
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
+use Girgias\StubToDocbook\MetaData\Functions\ParameterMetaData;
+use Girgias\StubToDocbook\Types\SingleType;
+use PHPUnit\Framework\TestCase;
+
+class MissingFunctionsGeneratorTest extends TestCase
+{
+    public function test_generate_single_function(): void
+    {
+        $fn = new FunctionMetaData(
+            'my_func',
+            [new ParameterMetaData('arg', 1, new SingleType('string'))],
+            new SingleType('bool'),
+            'ext_test',
+        );
+
+        $xml = MissingFunctionsGenerator::generateOne($fn);
+
+        self::assertStringContainsString('<methodsynopsis>', $xml);
+        self::assertStringContainsString('<methodname>my_func</methodname>', $xml);
+        self::assertStringContainsString('<type>bool</type>', $xml);
+        self::assertStringContainsString('<parameter>arg</parameter>', $xml);
+    }
+
+    public function test_generate_by_extension(): void
+    {
+        $fn1 = new FunctionMetaData('a_func', [], new SingleType('void'), 'ext_a');
+        $fn2 = new FunctionMetaData('b_func', [], new SingleType('int'), 'ext_b');
+        $fn3 = new FunctionMetaData('a_other', [], new SingleType('string'), 'ext_a');
+
+        $result = MissingFunctionsGenerator::generateByExtension([
+            'a_func' => $fn1,
+            'b_func' => $fn2,
+            'a_other' => $fn3,
+        ]);
+
+        self::assertCount(2, $result);
+        self::assertArrayHasKey('ext_a', $result);
+        self::assertArrayHasKey('ext_b', $result);
+        self::assertCount(2, $result['ext_a']);
+        self::assertCount(1, $result['ext_b']);
+    }
+}

--- a/tests/MetaData/Functions/FunctionMetaDataTest.php
+++ b/tests/MetaData/Functions/FunctionMetaDataTest.php
@@ -603,6 +603,7 @@ XML;
         $document->append($element);
 
         $xml = $document->saveXml($element);
+        self::assertIsString($xml);
 
         self::assertStringContainsString('<methodname>array_pop</methodname>', $xml);
         self::assertStringContainsString('<type>mixed</type>', $xml);
@@ -625,6 +626,7 @@ XML;
         $document->append($element);
 
         $xml = $document->saveXml($element);
+        self::assertIsString($xml);
 
         self::assertStringContainsString('<void/>', $xml);
         self::assertStringNotContainsString('<methodparam', $xml);
@@ -647,6 +649,7 @@ XML;
         $document->append($element);
 
         $xml = $document->saveXml($element);
+        self::assertIsString($xml);
 
         self::assertStringContainsString('<modifier>final</modifier>', $xml);
         self::assertStringContainsString('<modifier>protected</modifier>', $xml);
@@ -678,6 +681,7 @@ XML;
         $document->append($element);
 
         $xml = $document->saveXml($element);
+        self::assertIsString($xml);
 
         self::assertStringContainsString('choice="opt"', $xml);
         self::assertStringContainsString('<initializer>null</initializer>', $xml);


### PR DESCRIPTION
## Summary
- Add `MissingFunctionsGenerator` class
- `generateOne()` produces DocBook `<methodsynopsis>` XML for a single function
- `generateByExtension()` groups output by extension name
- 2 tests
- Depends on #64 (toMethodSynopsisXml)

Closes #38