### PR TITLE
Add DocBookLoader utility for entity handling

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,12 +21,6 @@ parameters:
             path: scripts/parse-stub.php
 
         -
-            message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|false given\.$#'
-            identifier: argument.type
-            count: 1
-            path: scripts/parse-stub.php
-
-        -
             message: '#^Only iterables can be unpacked, list\<string\>\|false given\.$#'
             identifier: arrayUnpacking.nonIterable
             count: 2

--- a/scripts/parse-stub.php
+++ b/scripts/parse-stub.php
@@ -1,7 +1,7 @@
 <?php
 
-use Dom\XMLDocument;
 use Girgias\StubToDocbook\Differ\ConstantListDiffer;
+use Girgias\StubToDocbook\Documentation\DocBookLoader;
 use Girgias\StubToDocbook\Documentation\DocumentedConstantParser;
 use Girgias\StubToDocbook\MetaData\Lists\ConstantList;
 use Girgias\StubToDocbook\Reports\ConstantDocumentationReport;
@@ -9,22 +9,7 @@ use Girgias\StubToDocbook\Reports\ConstantDocumentationReport;
 $totalDocConst = 0;
 function file_to_doc_constants(string $path)
 {
-    $content = file_get_contents($path);
-    $content = str_replace(
-        [
-            '&true;',
-            '&false;',
-            '&null;',
-        ],
-        [
-            '<constant xmlns="http://docbook.org/ns/docbook">true</constant>',
-            '<constant xmlns="http://docbook.org/ns/docbook">false</constant>',
-            '<constant xmlns="http://docbook.org/ns/docbook">null</constant>',
-        ],
-        $content,
-    );
-    $content = str_replace('&', '&amp;', $content);
-    $dom = XMLDocument::createFromString($content);
+    $dom = DocBookLoader::loadFile($path);
     //echo "File $path\n";
     // TODO: Determine extension properly from file path
     $listOfDocumentedConstantList = DocumentedConstantParser::parse($dom, 'UNKNOWN');

--- a/src/Documentation/DocBookLoader.php
+++ b/src/Documentation/DocBookLoader.php
@@ -23,7 +23,7 @@ final class DocBookLoader
      */
     public static function loadFile(string $path): XMLDocument
     {
-        $content = file_get_contents($path);
+        $content = @file_get_contents($path);
         if ($content === false) {
             throw new \RuntimeException('Failed to read file: ' . $path);
         }

--- a/src/Documentation/DocBookLoader.php
+++ b/src/Documentation/DocBookLoader.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Girgias\StubToDocbook\Documentation;
+
+use Dom\XMLDocument;
+
+final class DocBookLoader
+{
+    /**
+     * Known DocBook entities used in PHP documentation that map to XML equivalents.
+     */
+    private const ENTITY_REPLACEMENTS = [
+        '&true;' => '<constant xmlns="http://docbook.org/ns/docbook">true</constant>',
+        '&false;' => '<constant xmlns="http://docbook.org/ns/docbook">false</constant>',
+        '&null;' => '<constant xmlns="http://docbook.org/ns/docbook">null</constant>',
+    ];
+
+    /**
+     * Load a DocBook XML file, handling entities that cannot be expanded.
+     *
+     * Replaces known entities with their XML equivalents and escapes
+     * remaining entity references to prevent parsing errors.
+     */
+    public static function loadFile(string $path): XMLDocument
+    {
+        $content = file_get_contents($path);
+        if ($content === false) {
+            throw new \RuntimeException('Failed to read file: ' . $path);
+        }
+        return self::loadString($content);
+    }
+
+    /**
+     * Load a DocBook XML string, handling entities that cannot be expanded.
+     */
+    public static function loadString(string $content): XMLDocument
+    {
+        $content = self::replaceEntities($content);
+        return XMLDocument::createFromString($content);
+    }
+
+    /**
+     * Replace known entities with XML equivalents and escape remaining ampersands.
+     */
+    public static function replaceEntities(string $content): string
+    {
+        // Replace known entities with their XML equivalents
+        $content = str_replace(
+            array_keys(self::ENTITY_REPLACEMENTS),
+            array_values(self::ENTITY_REPLACEMENTS),
+            $content,
+        );
+
+        // Escape remaining entity references (e.g. &reftitle.description;)
+        $content = str_replace('&', '&amp;', $content);
+
+        return $content;
+    }
+}

--- a/tests/Documentation/DocBookLoaderTest.php
+++ b/tests/Documentation/DocBookLoaderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Documentation;
+
+use Dom\XMLDocument;
+use Girgias\StubToDocbook\Documentation\DocBookLoader;
+use PHPUnit\Framework\TestCase;
+
+class DocBookLoaderTest extends TestCase
+{
+    public function test_known_entities_are_replaced(): void
+    {
+        $xml = '<?xml version="1.0" encoding="utf-8"?>'
+            . '<root xmlns="http://docbook.org/ns/docbook">'
+            . '<para>Value is &true; or &false; or &null;</para>'
+            . '</root>';
+
+        $doc = DocBookLoader::loadString($xml);
+
+        $constants = $doc->getElementsByTagName('constant');
+        self::assertSame(3, $constants->length);
+        self::assertSame('true', $constants->item(0)->textContent);
+        self::assertSame('false', $constants->item(1)->textContent);
+        self::assertSame('null', $constants->item(2)->textContent);
+    }
+
+    public function test_unknown_entities_are_escaped(): void
+    {
+        $xml = '<?xml version="1.0" encoding="utf-8"?>'
+            . '<root xmlns="http://docbook.org/ns/docbook">'
+            . '<para>&reftitle.description;</para>'
+            . '</root>';
+
+        $doc = DocBookLoader::loadString($xml);
+
+        self::assertInstanceOf(XMLDocument::class, $doc);
+        self::assertStringContainsString('&amp;reftitle.description;', $doc->saveXml());
+    }
+
+    public function test_load_file_with_nonexistent_path(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        DocBookLoader::loadFile('/nonexistent/path.xml');
+    }
+}

--- a/tests/Documentation/DocBookLoaderTest.php
+++ b/tests/Documentation/DocBookLoaderTest.php
@@ -34,7 +34,9 @@ class DocBookLoaderTest extends TestCase
         $doc = DocBookLoader::loadString($xml);
 
         self::assertInstanceOf(XMLDocument::class, $doc);
-        self::assertStringContainsString('&amp;reftitle.description;', $doc->saveXml());
+        $xml = $doc->saveXml();
+        self::assertIsString($xml);
+        self::assertStringContainsString('&amp;reftitle.description;', $xml);
     }
 
     public function test_load_file_with_nonexistent_path(): void


### PR DESCRIPTION
## Summary
- Create `DocBookLoader` class that centralizes DocBook entity replacement and XML loading
- Replaces known entities (`&true;`, `&false;`, `&null;`) with XML equivalents
- Escapes remaining entity references to prevent parsing errors
- Refactor `parse-stub.php` to use the new utility
- Add tests for entity handling

Closes #21