### PR TITLE
Add token constant list parsing

### DIFF
--- a/src/Documentation/DocumentedConstantListType.php
+++ b/src/Documentation/DocumentedConstantListType.php
@@ -6,4 +6,5 @@ enum DocumentedConstantListType
 {
     case VarEntryList;
     case Table;
+    case TokenList;
 }

--- a/src/Documentation/DocumentedConstantParser.php
+++ b/src/Documentation/DocumentedConstantParser.php
@@ -111,4 +111,43 @@ class DocumentedConstantParser
         }
         return $constants;
     }
+
+    /**
+     * Parse token constant list from a DocBook document (e.g. appendices/tokens.xml).
+     * Token constants are all of type int.
+     *
+     * @return ConstantList
+     */
+    public static function parseTokenList(XMLDocument $doc, string $extension): ConstantList
+    {
+        $individualList = [];
+        $tables = $doc->getElementsByTagName('table');
+        foreach ($tables as $table) {
+            $tbody = $table->getElementsByTagName("tbody")->item(0);
+            if ($tbody === null) {
+                continue;
+            }
+            foreach ($tbody->getElementsByTagName("row") as $row) {
+                $entries = $row->getElementsByTagName("entry");
+                if (count($entries) < 1) {
+                    continue;
+                }
+                $constantTags = $entries[0]->getElementsByTagName("constant");
+                if ($constantTags->length === 0) {
+                    continue;
+                }
+                $constantName = $constantTags[0]->textContent;
+                $id = 'constant.' . xmlify_labels($constantName);
+
+                $individualList[$constantName] = new ConstantMetaData(
+                    $constantName,
+                    new SingleType('int'),
+                    $extension,
+                    $id,
+                );
+            }
+        }
+
+        return new ConstantList($individualList, DocumentedConstantListType::TokenList);
+    }
 }

--- a/tests/Documentation/DocumentedConstantParserTest.php
+++ b/tests/Documentation/DocumentedConstantParserTest.php
@@ -145,4 +145,49 @@ FILE;
         self::assertArrayHasKey('STDOUT', $constants[1]->constants);
         self::assertSame('STDOUT', $constants[1]->constants['STDOUT']->name);
     }
+
+    const /* string */ TOKEN_LIST = <<<'FILE'
+<?xml version="1.0" encoding="utf-8"?>
+<appendix xml:id="tokens" xmlns="http://docbook.org/ns/docbook">
+ <title>List of Parser Tokens</title>
+ <table>
+  <title>Tokens</title>
+  <tgroup cols="2">
+   <thead>
+    <row>
+     <entry>Token</entry>
+     <entry>Syntax</entry>
+    </row>
+   </thead>
+   <tbody>
+    <row>
+     <entry><constant>T_ABSTRACT</constant></entry>
+     <entry>abstract</entry>
+    </row>
+    <row>
+     <entry><constant>T_AND_EQUAL</constant></entry>
+     <entry>&amp;amp;=</entry>
+    </row>
+    <row>
+     <entry><constant>T_ARRAY</constant></entry>
+     <entry>array()</entry>
+    </row>
+   </tbody>
+  </tgroup>
+ </table>
+</appendix>
+FILE;
+
+    public function test_parsing_token_list(): void
+    {
+        $document = XMLDocument::createFromString(self::TOKEN_LIST);
+        $tokenList = DocumentedConstantParser::parseTokenList($document, 'tokenizer');
+
+        self::assertCount(3, $tokenList);
+        self::assertArrayHasKey('T_ABSTRACT', $tokenList->constants);
+        self::assertSame('int', $tokenList->constants['T_ABSTRACT']->type->name);
+        self::assertSame('constant.t-abstract', $tokenList->constants['T_ABSTRACT']->id);
+        self::assertArrayHasKey('T_AND_EQUAL', $tokenList->constants);
+        self::assertArrayHasKey('T_ARRAY', $tokenList->constants);
+    }
 }

--- a/tests/Documentation/DocumentedConstantParserTest.php
+++ b/tests/Documentation/DocumentedConstantParserTest.php
@@ -146,7 +146,7 @@ FILE;
         self::assertSame('STDOUT', $constants[1]->constants['STDOUT']->name);
     }
 
-    const /* string */ TOKEN_LIST = <<<'FILE'
+    public const /* string */ TOKEN_LIST = <<<'FILE'
 <?xml version="1.0" encoding="utf-8"?>
 <appendix xml:id="tokens" xmlns="http://docbook.org/ns/docbook">
  <title>List of Parser Tokens</title>


### PR DESCRIPTION
## Summary
- Add `parseTokenList()` method to `DocumentedConstantParser` for token constant tables
- Token constants are parsed with `int` type and auto-generated IDs
- Add `TokenList` case to `DocumentedConstantListType` enum
- Add test with token list XML fixture

Closes #24