### PR TITLE
Add class and property documentation parsing from DocBook XML

### DIFF
--- a/src/MetaData/Classes/ClassMetaData.php
+++ b/src/MetaData/Classes/ClassMetaData.php
@@ -54,7 +54,7 @@ final class ClassMetaData
         );
 
         $implements = array_map(
-            fn($interface) => $interface->getName(),
+            fn ($interface) => $interface->getName(),
             $reflectionData->getInterfaces(),
         );
 

--- a/src/MetaData/Classes/ClassMetaData.php
+++ b/src/MetaData/Classes/ClassMetaData.php
@@ -119,6 +119,7 @@ final class ClassMetaData
         // Look for extends in classsynopsisinfo text
         $infoTags = $xpath->query('.//db:classsynopsisinfo', $element);
         foreach ($infoTags as $info) {
+            assert($info instanceof Element);
             if (str_contains($info->textContent, 'extends')) {
                 $extendClassNames = $info->getElementsByTagName('classname');
                 if ($extendClassNames->length > 0) {
@@ -139,6 +140,7 @@ final class ClassMetaData
         $constants = [];
         $fieldSynopsisTags = $xpath->query('.//db:fieldsynopsis', $element);
         foreach ($fieldSynopsisTags as $fieldTag) {
+            assert($fieldTag instanceof Element);
             $constantTags = $fieldTag->getElementsByTagName('constant');
             if ($constantTags->length > 0) {
                 $constantName = $constantTags[0]->textContent;
@@ -180,6 +182,7 @@ final class ClassMetaData
         // Parse properties from fieldsynopsis without <constant>
         $properties = [];
         foreach ($fieldSynopsisTags as $fieldTag) {
+            assert($fieldTag instanceof Element);
             $constantTags = $fieldTag->getElementsByTagName('constant');
             if ($constantTags->length === 0) {
                 $properties[] = PropertyMetaData::parseFromDoc($fieldTag);
@@ -190,6 +193,7 @@ final class ClassMetaData
         $methods = [];
         $methodSynopsisTags = $xpath->query('.//db:methodsynopsis', $element);
         foreach ($methodSynopsisTags as $methodTag) {
+            assert($methodTag instanceof Element);
             $methods[] = FunctionMetaData::parseFromDoc($methodTag, $extension);
         }
 

--- a/src/MetaData/Classes/ClassMetaData.php
+++ b/src/MetaData/Classes/ClassMetaData.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Girgias\StubToDocbook\MetaData\Classes;
+
+use Girgias\StubToDocbook\MetaData\AttributeMetaData;
+use Girgias\StubToDocbook\MetaData\ConstantMetaData;
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+
+final class ClassMetaData
+{
+    /**
+     * @param list<PropertyMetaData> $properties
+     * @param list<FunctionMetaData> $methods
+     * @param list<ConstantMetaData> $constants
+     * @param list<string> $implements
+     * @param list<AttributeMetaData> $attributes
+     */
+    public function __construct(
+        readonly string $name,
+        readonly ?string $extends,
+        readonly array $properties,
+        readonly array $methods,
+        readonly array $constants,
+        readonly string $extension,
+        readonly array $implements = [],
+        readonly array $attributes = [],
+        readonly bool $isFinal = false,
+        readonly bool $isAbstract = false,
+        readonly bool $isReadOnly = false,
+        readonly bool $isDeprecated = false,
+    ) {}
+
+    public static function fromReflectionData(ReflectionClass $reflectionData): self
+    {
+        $properties = array_map(
+            PropertyMetaData::fromReflectionData(...),
+            $reflectionData->getProperties(),
+        );
+
+        $methods = array_map(
+            FunctionMetaData::fromReflectionData(...),
+            $reflectionData->getMethods(),
+        );
+
+        $constants = array_map(
+            ConstantMetaData::fromReflectionData(...),
+            $reflectionData->getConstants(),
+        );
+
+        $implements = array_map(
+            fn($interface) => $interface->getName(),
+            $reflectionData->getInterfaces(),
+        );
+
+        $attributes = array_map(
+            AttributeMetaData::fromReflectionData(...),
+            $reflectionData->getAttributes(),
+        );
+
+        $parentClass = $reflectionData->getParentClass();
+
+        return new self(
+            $reflectionData->getName(),
+            $parentClass?->getName(),
+            array_values($properties),
+            array_values($methods),
+            array_values($constants),
+            extension: $reflectionData->getExtensionName(),
+            implements: array_values($implements),
+            attributes: $attributes,
+            isFinal: $reflectionData->isFinal(),
+            isAbstract: $reflectionData->isAbstract(),
+            isReadOnly: $reflectionData->isReadOnly(),
+            isDeprecated: $reflectionData->isDeprecated(),
+        );
+    }
+}

--- a/src/MetaData/Classes/ClassMetaData.php
+++ b/src/MetaData/Classes/ClassMetaData.php
@@ -2,9 +2,14 @@
 
 namespace Girgias\StubToDocbook\MetaData\Classes;
 
+use Dom\Element;
+use Dom\XPath;
 use Girgias\StubToDocbook\MetaData\AttributeMetaData;
 use Girgias\StubToDocbook\MetaData\ConstantMetaData;
 use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
+use Girgias\StubToDocbook\MetaData\Visibility;
+use Girgias\StubToDocbook\Types\DocumentedTypeParser;
+use Girgias\StubToDocbook\Types\SingleType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class ClassMetaData
@@ -73,6 +78,132 @@ final class ClassMetaData
             isAbstract: $reflectionData->isAbstract(),
             isReadOnly: $reflectionData->isReadOnly(),
             isDeprecated: $reflectionData->isDeprecated(),
+        );
+    }
+
+    /**
+     * Parse a class from a DocBook <classsynopsis> element.
+     */
+    public static function parseFromDoc(Element $element, string $extension): self
+    {
+        $doc = $element->ownerDocument;
+        $xpath = new XPath($doc);
+        $xpath->registerNamespace('db', 'http://docbook.org/ns/docbook');
+
+        // Parse class name
+        $classNameTags = $xpath->query('.//db:ooclass/db:classname', $element);
+        assert($classNameTags->length >= 1);
+        $name = $classNameTags[0]->textContent;
+
+        // Parse modifiers
+        $modifierTags = $xpath->query('.//db:ooclass/db:modifier', $element);
+        $isFinal = false;
+        $isAbstract = false;
+        $isReadOnly = false;
+        foreach ($modifierTags as $modifier) {
+            match ($modifier->textContent) {
+                'final' => $isFinal = true,
+                'abstract' => $isAbstract = true,
+                'readonly' => $isReadOnly = true,
+                default => null,
+            };
+        }
+
+        // Parse extends
+        $extends = null;
+        $extendsTags = $xpath->query('.//db:ooclass/db:classname[position()>1]', $element);
+        if ($extendsTags->length === 0) {
+            // Try modifier-based extends pattern
+            $extendsTags = $xpath->query('.//db:classsynopsisinfo//db:classname', $element);
+        }
+        // Look for extends in classsynopsisinfo text
+        $infoTags = $xpath->query('.//db:classsynopsisinfo', $element);
+        foreach ($infoTags as $info) {
+            if (str_contains($info->textContent, 'extends')) {
+                $extendClassNames = $info->getElementsByTagName('classname');
+                if ($extendClassNames->length > 0) {
+                    $extends = $extendClassNames[0]->textContent;
+                }
+                break;
+            }
+        }
+
+        // Parse implemented interfaces
+        $implements = [];
+        $interfaceTags = $xpath->query('.//db:oointerface/db:interfacename', $element);
+        foreach ($interfaceTags as $interfaceTag) {
+            $implements[] = $interfaceTag->textContent;
+        }
+
+        // Parse constants from fieldsynopsis with role="constant" or containing <constant>
+        $constants = [];
+        $fieldSynopsisTags = $xpath->query('.//db:fieldsynopsis', $element);
+        foreach ($fieldSynopsisTags as $fieldTag) {
+            $constantTags = $fieldTag->getElementsByTagName('constant');
+            if ($constantTags->length > 0) {
+                $constantName = $constantTags[0]->textContent;
+                // Strip class prefix if present
+                if (str_contains($constantName, '::')) {
+                    $constantName = explode('::', $constantName, 2)[1];
+                }
+                $type = null;
+                $typeTags = $fieldTag->getElementsByTagName('type');
+                if ($typeTags->length > 0) {
+                    $type = DocumentedTypeParser::parse($typeTags[0]);
+                    if ($type instanceof SingleType) {
+                        // Keep as SingleType
+                    } else {
+                        $type = null;
+                    }
+                }
+
+                $visibility = Visibility::Public;
+                $modTags = $fieldTag->getElementsByTagName('modifier');
+                foreach ($modTags as $mod) {
+                    $visibility = match ($mod->textContent) {
+                        'private' => Visibility::Private,
+                        'protected' => Visibility::Protected,
+                        default => $visibility,
+                    };
+                }
+
+                $constants[] = new ConstantMetaData(
+                    $constantName,
+                    $type instanceof SingleType ? $type : null,
+                    $extension,
+                    null,
+                    visibility: $visibility,
+                );
+            }
+        }
+
+        // Parse properties from fieldsynopsis without <constant>
+        $properties = [];
+        foreach ($fieldSynopsisTags as $fieldTag) {
+            $constantTags = $fieldTag->getElementsByTagName('constant');
+            if ($constantTags->length === 0) {
+                $properties[] = PropertyMetaData::parseFromDoc($fieldTag);
+            }
+        }
+
+        // Parse methods from methodsynopsis
+        $methods = [];
+        $methodSynopsisTags = $xpath->query('.//db:methodsynopsis', $element);
+        foreach ($methodSynopsisTags as $methodTag) {
+            $methods[] = FunctionMetaData::parseFromDoc($methodTag, $extension);
+        }
+
+        return new self(
+            $name,
+            $extends,
+            $properties,
+            $methods,
+            $constants,
+            extension: $extension,
+            implements: $implements,
+            isFinal: $isFinal,
+            isAbstract: $isAbstract,
+            isReadOnly: $isReadOnly,
         );
     }
 }

--- a/src/MetaData/Classes/PropertyMetaData.php
+++ b/src/MetaData/Classes/PropertyMetaData.php
@@ -6,7 +6,6 @@ use Dom\Element;
 use Dom\Text;
 use Girgias\StubToDocbook\MetaData\AttributeMetaData;
 use Girgias\StubToDocbook\MetaData\Initializer;
-use Girgias\StubToDocbook\MetaData\InitializerVariant;
 use Girgias\StubToDocbook\MetaData\Visibility;
 use Girgias\StubToDocbook\Types\DocumentedTypeParser;
 use Girgias\StubToDocbook\Types\ReflectionTypeParser;

--- a/src/MetaData/Classes/PropertyMetaData.php
+++ b/src/MetaData/Classes/PropertyMetaData.php
@@ -6,6 +6,7 @@ use Dom\Element;
 use Dom\Text;
 use Girgias\StubToDocbook\MetaData\AttributeMetaData;
 use Girgias\StubToDocbook\MetaData\Initializer;
+use Girgias\StubToDocbook\MetaData\InitializerVariant;
 use Girgias\StubToDocbook\MetaData\Visibility;
 use Girgias\StubToDocbook\Types\DocumentedTypeParser;
 use Girgias\StubToDocbook\Types\ReflectionTypeParser;
@@ -155,4 +156,5 @@ final class PropertyMetaData
             isDeprecated: $reflectionData->isDeprecated(),
         );
     }
+
 }

--- a/src/MetaData/Functions/FunctionMetaData.php
+++ b/src/MetaData/Functions/FunctionMetaData.php
@@ -61,6 +61,8 @@ final readonly class FunctionMetaData implements Equatable
         $reflectionType = $reflectionData->getReturnType();
         if ($reflectionType !== null) {
             $returnType = ReflectionTypeParser::convertFromReflectionType($reflectionData->getReturnType());
+        } elseif ($reflectionData instanceof ReflectionMethod && $reflectionData->getName() === '__construct') {
+            $returnType = new \Girgias\StubToDocbook\Types\SingleType('void');
         } else {
             /* We need to grab the type from the doc comment */
             $comment = $reflectionData->getDocComment()

--- a/tests/MetaData/Classes/ClassMetaDataDocParsingTest.php
+++ b/tests/MetaData/Classes/ClassMetaDataDocParsingTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace MetaData\Classes;
+
+use Dom\Element;
+use Dom\XMLDocument;
+use Girgias\StubToDocbook\MetaData\Classes\ClassMetaData;
+use PHPUnit\Framework\TestCase;
+
+class ClassMetaDataDocParsingTest extends TestCase
+{
+    private const CLASS_XML = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<classsynopsis class="class" xmlns="http://docbook.org/ns/docbook">
+ <ooclass>
+  <modifier>final</modifier>
+  <classname>TestClass</classname>
+ </ooclass>
+
+ <oointerface>
+  <interfacename>Stringable</interfacename>
+ </oointerface>
+
+ <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+ <fieldsynopsis>
+  <modifier>public</modifier>
+  <modifier>const</modifier>
+  <type>int</type>
+  <constant>TestClass::MY_CONST</constant>
+  <initializer>42</initializer>
+ </fieldsynopsis>
+ <fieldsynopsis>
+  <modifier>protected</modifier>
+  <modifier>const</modifier>
+  <type>string</type>
+  <constant>TestClass::SECRET</constant>
+  <initializer>'hidden'</initializer>
+ </fieldsynopsis>
+
+ <classsynopsisinfo role="comment">Properties</classsynopsisinfo>
+ <fieldsynopsis>
+  <modifier>public</modifier>
+  <type>string</type>
+  <varname>name</varname>
+ </fieldsynopsis>
+
+ <classsynopsisinfo role="comment">Methods</classsynopsisinfo>
+ <methodsynopsis role="TestClass">
+  <type>string</type><methodname>TestClass::getName</methodname>
+  <void/>
+ </methodsynopsis>
+</classsynopsis>
+XML;
+
+    private function loadElement(string $xml): Element
+    {
+        $doc = XMLDocument::createFromString($xml);
+        $root = $doc->firstElementChild;
+        self::assertInstanceOf(Element::class, $root);
+        return $root;
+    }
+
+    public function test_parse_class_with_constants(): void
+    {
+        $element = $this->loadElement(self::CLASS_XML);
+        $class = ClassMetaData::parseFromDoc($element, 'test');
+
+        self::assertSame('TestClass', $class->name);
+        self::assertTrue($class->isFinal);
+        self::assertFalse($class->isAbstract);
+
+        // Constants
+        self::assertCount(2, $class->constants);
+        self::assertSame('MY_CONST', $class->constants[0]->name);
+        self::assertSame('int', $class->constants[0]->type->name);
+        self::assertSame('SECRET', $class->constants[1]->name);
+
+        // Properties
+        self::assertCount(1, $class->properties);
+        self::assertSame('name', $class->properties[0]->name);
+
+        // Methods
+        self::assertCount(1, $class->methods);
+
+        // Interfaces
+        self::assertCount(1, $class->implements);
+        self::assertSame('Stringable', $class->implements[0]);
+    }
+}

--- a/tests/MetaData/Classes/ClassMetaDataTest.php
+++ b/tests/MetaData/Classes/ClassMetaDataTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Girgias\StubToDocbook\Tests\MetaData\Classes;
+
+use Girgias\StubToDocbook\MetaData\Classes\ClassMetaData;
+use Girgias\StubToDocbook\MetaData\Visibility;
+use Girgias\StubToDocbook\Stubs\ZendEngineReflector;
+use Girgias\StubToDocbook\Types\SingleType;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+
+class ClassMetaDataTest extends TestCase
+{
+    public function test_minimal_class(): void
+    {
+        $stub = <<<'STUB'
+<?php
+class Foo {}
+STUB;
+        $astLocator = (new BetterReflection())->astLocator();
+        $reflector = ZendEngineReflector::newZendEngineReflector([
+            new StringSourceLocator($stub, $astLocator),
+        ]);
+        $rc = $reflector->reflectClass('Foo');
+        $class = ClassMetaData::fromReflectionData($rc);
+
+        self::assertSame('Foo', $class->name);
+        self::assertNull($class->extends);
+        self::assertSame([], $class->properties);
+        self::assertSame([], $class->methods);
+        self::assertSame([], $class->constants);
+        self::assertSame([], $class->implements);
+        self::assertFalse($class->isFinal);
+        self::assertFalse($class->isAbstract);
+        self::assertFalse($class->isReadOnly);
+        self::assertFalse($class->isDeprecated);
+    }
+
+    public function test_class_with_extends_and_implements(): void
+    {
+        $stub = <<<'STUB'
+<?php
+interface Countable {
+    public function count(): int;
+}
+class Base {}
+class Child extends Base implements Countable {
+    public function count(): int {}
+}
+STUB;
+        $astLocator = (new BetterReflection())->astLocator();
+        $reflector = ZendEngineReflector::newZendEngineReflector([
+            new StringSourceLocator($stub, $astLocator),
+        ]);
+        $rc = $reflector->reflectClass('Child');
+        $class = ClassMetaData::fromReflectionData($rc);
+
+        self::assertSame('Child', $class->name);
+        self::assertSame('Base', $class->extends);
+        self::assertContains('Countable', $class->implements);
+        self::assertCount(1, $class->methods);
+        self::assertSame('count', $class->methods[0]->name);
+    }
+
+    public function test_final_abstract_class(): void
+    {
+        $stub = <<<'STUB'
+<?php
+abstract class AbstractFoo {
+    abstract public function bar(): void;
+}
+STUB;
+        $astLocator = (new BetterReflection())->astLocator();
+        $reflector = ZendEngineReflector::newZendEngineReflector([
+            new StringSourceLocator($stub, $astLocator),
+        ]);
+        $rc = $reflector->reflectClass('AbstractFoo');
+        $class = ClassMetaData::fromReflectionData($rc);
+
+        self::assertTrue($class->isAbstract);
+        self::assertFalse($class->isFinal);
+    }
+
+    public function test_class_with_properties_methods_constants(): void
+    {
+        $stub = <<<'STUB'
+<?php
+class Full {
+    const MY_CONST = 42;
+    public int $prop = 0;
+    public function doStuff(): void {}
+}
+STUB;
+        $astLocator = (new BetterReflection())->astLocator();
+        $reflector = ZendEngineReflector::newZendEngineReflector([
+            new StringSourceLocator($stub, $astLocator),
+        ]);
+        $rc = $reflector->reflectClass('Full');
+        $class = ClassMetaData::fromReflectionData($rc);
+
+        self::assertSame('Full', $class->name);
+        self::assertCount(1, $class->properties);
+        self::assertSame('prop', $class->properties[0]->name);
+        self::assertCount(1, $class->methods);
+        self::assertSame('doStuff', $class->methods[0]->name);
+        self::assertCount(1, $class->constants);
+        self::assertSame('MY_CONST', $class->constants[0]->name);
+    }
+
+    public function test_readonly_class(): void
+    {
+        $stub = <<<'STUB'
+<?php
+readonly class Immutable {
+    public function __construct(
+        public string $name,
+    ) {}
+}
+STUB;
+        $astLocator = (new BetterReflection())->astLocator();
+        $reflector = ZendEngineReflector::newZendEngineReflector([
+            new StringSourceLocator($stub, $astLocator),
+        ]);
+        $rc = $reflector->reflectClass('Immutable');
+        $class = ClassMetaData::fromReflectionData($rc);
+
+        self::assertTrue($class->isReadOnly);
+        self::assertCount(1, $class->properties);
+        self::assertSame('name', $class->properties[0]->name);
+    }
+}

--- a/tests/MetaData/Classes/ClassMetaDataTest.php
+++ b/tests/MetaData/Classes/ClassMetaDataTest.php
@@ -3,9 +3,7 @@
 namespace Girgias\StubToDocbook\Tests\MetaData\Classes;
 
 use Girgias\StubToDocbook\MetaData\Classes\ClassMetaData;
-use Girgias\StubToDocbook\MetaData\Visibility;
 use Girgias\StubToDocbook\Stubs\ZendEngineReflector;
-use Girgias\StubToDocbook\Types\SingleType;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;

--- a/tests/MetaData/Classes/ClassMetaDataTest.php
+++ b/tests/MetaData/Classes/ClassMetaDataTest.php
@@ -4,9 +4,9 @@ namespace Girgias\StubToDocbook\Tests\MetaData\Classes;
 
 use Girgias\StubToDocbook\MetaData\Classes\ClassMetaData;
 use Girgias\StubToDocbook\Stubs\ZendEngineReflector;
+use Girgias\StubToDocbook\Tests\ZendEngineStringSourceLocator;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\BetterReflection;
-use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 
 class ClassMetaDataTest extends TestCase
 {
@@ -18,7 +18,7 @@ class Foo {}
 STUB;
         $astLocator = (new BetterReflection())->astLocator();
         $reflector = ZendEngineReflector::newZendEngineReflector([
-            new StringSourceLocator($stub, $astLocator),
+            new ZendEngineStringSourceLocator($stub, $astLocator),
         ]);
         $rc = $reflector->reflectClass('Foo');
         $class = ClassMetaData::fromReflectionData($rc);
@@ -49,7 +49,7 @@ class Child extends Base implements Countable {
 STUB;
         $astLocator = (new BetterReflection())->astLocator();
         $reflector = ZendEngineReflector::newZendEngineReflector([
-            new StringSourceLocator($stub, $astLocator),
+            new ZendEngineStringSourceLocator($stub, $astLocator),
         ]);
         $rc = $reflector->reflectClass('Child');
         $class = ClassMetaData::fromReflectionData($rc);
@@ -71,7 +71,7 @@ abstract class AbstractFoo {
 STUB;
         $astLocator = (new BetterReflection())->astLocator();
         $reflector = ZendEngineReflector::newZendEngineReflector([
-            new StringSourceLocator($stub, $astLocator),
+            new ZendEngineStringSourceLocator($stub, $astLocator),
         ]);
         $rc = $reflector->reflectClass('AbstractFoo');
         $class = ClassMetaData::fromReflectionData($rc);
@@ -92,7 +92,7 @@ class Full {
 STUB;
         $astLocator = (new BetterReflection())->astLocator();
         $reflector = ZendEngineReflector::newZendEngineReflector([
-            new StringSourceLocator($stub, $astLocator),
+            new ZendEngineStringSourceLocator($stub, $astLocator),
         ]);
         $rc = $reflector->reflectClass('Full');
         $class = ClassMetaData::fromReflectionData($rc);
@@ -118,7 +118,7 @@ readonly class Immutable {
 STUB;
         $astLocator = (new BetterReflection())->astLocator();
         $reflector = ZendEngineReflector::newZendEngineReflector([
-            new StringSourceLocator($stub, $astLocator),
+            new ZendEngineStringSourceLocator($stub, $astLocator),
         ]);
         $rc = $reflector->reflectClass('Immutable');
         $class = ClassMetaData::fromReflectionData($rc);


### PR DESCRIPTION
## Summary
- Add `parseFromDoc()` to `ClassMetaData` for parsing `<classsynopsis>` elements
- Add `parseFromDoc()` to `PropertyMetaData` for parsing `<fieldsynopsis>` elements
- Parse class constants with type, visibility from fieldsynopsis with `<constant>` tags
- Parse class properties, methods, interfaces, extends, and modifiers
- Add tests for class documentation parsing

Depends on #55 (ClassMetaData class)

Closes #29