### PR TITLE
Add class and enum diff between stub and documentation

### DIFF
--- a/src/Differ/ClassDiff.php
+++ b/src/Differ/ClassDiff.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Girgias\StubToDocbook\Differ;
+
+final readonly class ClassDiff
+{
+    public function __construct(
+        readonly string $className,
+        readonly MemberListDiff $constants,
+        readonly MemberListDiff $properties,
+        readonly MemberListDiff $methods,
+    ) {}
+
+    public function hasDifferences(): bool
+    {
+        return $this->constants->missing !== []
+            || $this->constants->extra !== []
+            || $this->properties->missing !== []
+            || $this->properties->extra !== []
+            || $this->methods->missing !== []
+            || $this->methods->extra !== [];
+    }
+}

--- a/src/Differ/EnumDiff.php
+++ b/src/Differ/EnumDiff.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Girgias\StubToDocbook\Differ;
+
+final readonly class EnumDiff
+{
+    public function __construct(
+        readonly string $enumName,
+        readonly MemberListDiff $cases,
+        readonly MemberListDiff $methods,
+        readonly bool $backingTypeMismatch = false,
+    ) {}
+
+    public function hasDifferences(): bool
+    {
+        return $this->cases->missing !== []
+            || $this->cases->extra !== []
+            || $this->methods->missing !== []
+            || $this->methods->extra !== []
+            || $this->backingTypeMismatch;
+    }
+}

--- a/src/Differ/MemberListDiff.php
+++ b/src/Differ/MemberListDiff.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Girgias\StubToDocbook\Differ;
+
+final readonly class MemberListDiff
+{
+    /**
+     * @param list<string> $missing Members in stub but not in doc
+     * @param list<string> $extra Members in doc but not in stub
+     * @param list<string> $matching Members present in both
+     */
+    public function __construct(
+        readonly array $missing,
+        readonly array $extra,
+        readonly array $matching,
+    ) {}
+}

--- a/src/Differ/MemberListDiffer.php
+++ b/src/Differ/MemberListDiffer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Girgias\StubToDocbook\Differ;
+
+final class MemberListDiffer
+{
+    /**
+     * Compare two lists of named members (e.g., methods, properties, constants, cases).
+     *
+     * @param list<string> $stubMembers Member names from stubs
+     * @param list<string> $docMembers Member names from documentation
+     */
+    public static function diff(array $stubMembers, array $docMembers): MemberListDiff
+    {
+        $missing = array_values(array_diff($stubMembers, $docMembers));
+        $extra = array_values(array_diff($docMembers, $stubMembers));
+        $matching = array_values(array_intersect($stubMembers, $docMembers));
+
+        return new MemberListDiff($missing, $extra, $matching);
+    }
+}

--- a/tests/Differ/MemberListDifferTest.php
+++ b/tests/Differ/MemberListDifferTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Differ;
+
+use Girgias\StubToDocbook\Differ\ClassDiff;
+use Girgias\StubToDocbook\Differ\EnumDiff;
+use Girgias\StubToDocbook\Differ\MemberListDiff;
+use Girgias\StubToDocbook\Differ\MemberListDiffer;
+use PHPUnit\Framework\TestCase;
+
+class MemberListDifferTest extends TestCase
+{
+    public function test_identical_lists(): void
+    {
+        $diff = MemberListDiffer::diff(['a', 'b', 'c'], ['a', 'b', 'c']);
+        self::assertSame([], $diff->missing);
+        self::assertSame([], $diff->extra);
+        self::assertSame(['a', 'b', 'c'], $diff->matching);
+    }
+
+    public function test_missing_members(): void
+    {
+        $diff = MemberListDiffer::diff(['a', 'b', 'c'], ['a']);
+        self::assertSame(['b', 'c'], $diff->missing);
+        self::assertSame([], $diff->extra);
+        self::assertSame(['a'], $diff->matching);
+    }
+
+    public function test_extra_members(): void
+    {
+        $diff = MemberListDiffer::diff(['a'], ['a', 'b', 'c']);
+        self::assertSame([], $diff->missing);
+        self::assertSame(['b', 'c'], $diff->extra);
+        self::assertSame(['a'], $diff->matching);
+    }
+
+    public function test_empty_lists(): void
+    {
+        $diff = MemberListDiffer::diff([], []);
+        self::assertSame([], $diff->missing);
+        self::assertSame([], $diff->extra);
+        self::assertSame([], $diff->matching);
+    }
+
+    public function test_enum_diff_has_differences(): void
+    {
+        $noDiff = new EnumDiff(
+            'TestEnum',
+            new MemberListDiff([], [], ['A', 'B']),
+            new MemberListDiff([], [], ['method']),
+        );
+        self::assertFalse($noDiff->hasDifferences());
+
+        $withDiff = new EnumDiff(
+            'TestEnum',
+            new MemberListDiff(['C'], [], ['A', 'B']),
+            new MemberListDiff([], [], ['method']),
+        );
+        self::assertTrue($withDiff->hasDifferences());
+
+        $backingMismatch = new EnumDiff(
+            'TestEnum',
+            new MemberListDiff([], [], []),
+            new MemberListDiff([], [], []),
+            backingTypeMismatch: true,
+        );
+        self::assertTrue($backingMismatch->hasDifferences());
+    }
+
+    public function test_class_diff_has_differences(): void
+    {
+        $noDiff = new ClassDiff(
+            'TestClass',
+            new MemberListDiff([], [], []),
+            new MemberListDiff([], [], []),
+            new MemberListDiff([], [], []),
+        );
+        self::assertFalse($noDiff->hasDifferences());
+
+        $withDiff = new ClassDiff(
+            'TestClass',
+            new MemberListDiff(['CONST_A'], [], []),
+            new MemberListDiff([], [], []),
+            new MemberListDiff([], ['extraMethod'], []),
+        );
+        self::assertTrue($withDiff->hasDifferences());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MemberListDiffer` for comparing named member lists (constants, properties, methods, cases)
- Add `MemberListDiff` result type with missing, extra, and matching arrays
- Add `ClassDiff` with constants/properties/methods comparison and `hasDifferences()`
- Add `EnumDiff` with cases/methods comparison, backing type mismatch, and `hasDifferences()`
- Add comprehensive tests

Closes #32
Closes #33