### PR TITLE
Add documentation coverage statistics reports

### DIFF
--- a/src/Reports/CoverageStatistics.php
+++ b/src/Reports/CoverageStatistics.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Girgias\StubToDocbook\Reports;
+
+final readonly class CoverageStatistics
+{
+    /**
+     * @param array<string, ExtensionCoverage> $extensions
+     */
+    public function __construct(
+        readonly int $totalSymbols,
+        readonly int $documentedSymbols,
+        readonly int $missingSymbols,
+        readonly array $extensions,
+    ) {}
+
+    public function coveragePercentage(): float
+    {
+        if ($this->totalSymbols === 0) {
+            return 100.0;
+        }
+        return round(($this->documentedSymbols / $this->totalSymbols) * 100, 2);
+    }
+
+    /**
+     * Generate a JSON report string.
+     */
+    public function toJson(): string
+    {
+        $data = [
+            'generated_at' => date('Y-m-d H:i:s'),
+            'total_symbols' => $this->totalSymbols,
+            'documented_symbols' => $this->documentedSymbols,
+            'missing_symbols' => $this->missingSymbols,
+            'coverage_percentage' => $this->coveragePercentage(),
+            'extensions' => [],
+        ];
+
+        foreach ($this->extensions as $name => $ext) {
+            $data['extensions'][$name] = [
+                'total' => $ext->total,
+                'documented' => $ext->documented,
+                'missing' => $ext->missing,
+                'coverage_percentage' => $ext->coveragePercentage(),
+            ];
+        }
+
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Build coverage statistics from stub and doc symbol counts grouped by extension.
+     *
+     * @param array<string, int> $stubCountByExtension Total symbols per extension from stubs
+     * @param array<string, int> $docCountByExtension Documented symbols per extension from docs
+     */
+    public static function fromExtensionCounts(array $stubCountByExtension, array $docCountByExtension): self
+    {
+        $extensions = [];
+        $totalSymbols = 0;
+        $documentedSymbols = 0;
+
+        foreach ($stubCountByExtension as $ext => $total) {
+            $documented = $docCountByExtension[$ext] ?? 0;
+            $extensions[$ext] = new ExtensionCoverage($ext, $total, $documented);
+            $totalSymbols += $total;
+            $documentedSymbols += $documented;
+        }
+
+        ksort($extensions);
+
+        return new self(
+            $totalSymbols,
+            $documentedSymbols,
+            $totalSymbols - $documentedSymbols,
+            $extensions,
+        );
+    }
+}

--- a/src/Reports/ExtensionCoverage.php
+++ b/src/Reports/ExtensionCoverage.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Girgias\StubToDocbook\Reports;
+
+final readonly class ExtensionCoverage
+{
+    public readonly int $missing;
+
+    public function __construct(
+        readonly string $name,
+        readonly int $total,
+        readonly int $documented,
+    ) {
+        $this->missing = $total - $documented;
+    }
+
+    public function coveragePercentage(): float
+    {
+        if ($this->total === 0) {
+            return 100.0;
+        }
+        return round(($this->documented / $this->total) * 100, 2);
+    }
+}

--- a/tests/Reports/CoverageStatisticsTest.php
+++ b/tests/Reports/CoverageStatisticsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Reports;
+
+use Girgias\StubToDocbook\Reports\CoverageStatistics;
+use Girgias\StubToDocbook\Reports\ExtensionCoverage;
+use PHPUnit\Framework\TestCase;
+
+class CoverageStatisticsTest extends TestCase
+{
+    public function test_coverage_percentage(): void
+    {
+        $stats = new CoverageStatistics(100, 75, 25, []);
+        self::assertSame(75.0, $stats->coveragePercentage());
+    }
+
+    public function test_empty_coverage(): void
+    {
+        $stats = new CoverageStatistics(0, 0, 0, []);
+        self::assertSame(100.0, $stats->coveragePercentage());
+    }
+
+    public function test_from_extension_counts(): void
+    {
+        $stubs = ['core' => 50, 'json' => 10, 'curl' => 30];
+        $docs = ['core' => 45, 'json' => 10];
+
+        $stats = CoverageStatistics::fromExtensionCounts($stubs, $docs);
+
+        self::assertSame(90, $stats->totalSymbols);
+        self::assertSame(55, $stats->documentedSymbols);
+        self::assertSame(35, $stats->missingSymbols);
+        self::assertCount(3, $stats->extensions);
+
+        // Extensions should be sorted alphabetically
+        $extNames = array_keys($stats->extensions);
+        self::assertSame(['core', 'curl', 'json'], $extNames);
+
+        // Core: 45/50
+        self::assertSame(90.0, $stats->extensions['core']->coveragePercentage());
+        // Json: 10/10
+        self::assertSame(100.0, $stats->extensions['json']->coveragePercentage());
+        // Curl: 0/30
+        self::assertSame(0.0, $stats->extensions['curl']->coveragePercentage());
+    }
+
+    public function test_json_output(): void
+    {
+        $stats = CoverageStatistics::fromExtensionCounts(
+            ['test' => 10],
+            ['test' => 8],
+        );
+
+        $json = $stats->toJson();
+        $data = json_decode($json, true);
+
+        self::assertSame(10, $data['total_symbols']);
+        self::assertSame(8, $data['documented_symbols']);
+        self::assertSame(2, $data['missing_symbols']);
+        self::assertEquals(80.0, $data['coverage_percentage']);
+        self::assertArrayHasKey('test', $data['extensions']);
+        self::assertArrayHasKey('generated_at', $data);
+    }
+
+    public function test_extension_coverage(): void
+    {
+        $ext = new ExtensionCoverage('test', 20, 15);
+        self::assertSame(5, $ext->missing);
+        self::assertSame(75.0, $ext->coveragePercentage());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CoverageStatistics` class for tracking documentation coverage
- Add `ExtensionCoverage` class for per-extension coverage data
- Support JSON output with `toJson()` method
- Build from extension symbol counts with `fromExtensionCounts()`
- Extensions sorted alphabetically in output
- Add comprehensive tests

Closes #52