### PR TITLE
Add migration guide generation from version diffs

### DIFF
--- a/src/Generator/MigrationGuideGenerator.php
+++ b/src/Generator/MigrationGuideGenerator.php
@@ -2,8 +2,8 @@
 
 namespace Girgias\StubToDocbook\Generator;
 
-use Dom\XMLDocument;
 use Dom\Element;
+use Dom\XMLDocument;
 
 final class MigrationGuideGenerator
 {

--- a/src/Generator/MigrationGuideGenerator.php
+++ b/src/Generator/MigrationGuideGenerator.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Girgias\StubToDocbook\Generator;
+
+use Dom\XMLDocument;
+use Dom\Element;
+
+final class MigrationGuideGenerator
+{
+    /**
+     * Generate a migration guide section for new functions.
+     *
+     * @param list<string> $newFunctions
+     */
+    public static function generateNewFunctionsSection(XMLDocument $document, array $newFunctions): Element
+    {
+        $section = $document->createElementNS('http://docbook.org/ns/docbook', 'sect2');
+        $section->setAttribute('xml:id', 'migration.new-functions');
+
+        $title = $document->createElementNS('http://docbook.org/ns/docbook', 'title');
+        $title->textContent = 'New Functions';
+        $section->append($title);
+
+        $list = $document->createElementNS('http://docbook.org/ns/docbook', 'simplelist');
+        foreach ($newFunctions as $func) {
+            $member = $document->createElementNS('http://docbook.org/ns/docbook', 'member');
+            $funcElement = $document->createElementNS('http://docbook.org/ns/docbook', 'function');
+            $funcElement->textContent = $func;
+            $member->append($funcElement);
+            $list->append("\n  ", $member);
+        }
+        $list->append("\n ");
+        $section->append("\n ", $list, "\n");
+
+        return $section;
+    }
+
+    /**
+     * Generate a migration guide section for deprecated functions.
+     *
+     * @param list<string> $deprecatedFunctions
+     */
+    public static function generateDeprecatedFunctionsSection(XMLDocument $document, array $deprecatedFunctions): Element
+    {
+        $section = $document->createElementNS('http://docbook.org/ns/docbook', 'sect2');
+        $section->setAttribute('xml:id', 'migration.deprecated-functions');
+
+        $title = $document->createElementNS('http://docbook.org/ns/docbook', 'title');
+        $title->textContent = 'Deprecated Functions';
+        $section->append($title);
+
+        $list = $document->createElementNS('http://docbook.org/ns/docbook', 'simplelist');
+        foreach ($deprecatedFunctions as $func) {
+            $member = $document->createElementNS('http://docbook.org/ns/docbook', 'member');
+            $funcElement = $document->createElementNS('http://docbook.org/ns/docbook', 'function');
+            $funcElement->textContent = $func;
+            $member->append($funcElement);
+            $list->append("\n  ", $member);
+        }
+        $list->append("\n ");
+        $section->append("\n ", $list, "\n");
+
+        return $section;
+    }
+
+    /**
+     * Generate a migration guide section for new constants.
+     *
+     * @param list<string> $newConstants
+     */
+    public static function generateNewConstantsSection(XMLDocument $document, array $newConstants): Element
+    {
+        $section = $document->createElementNS('http://docbook.org/ns/docbook', 'sect2');
+        $section->setAttribute('xml:id', 'migration.new-constants');
+
+        $title = $document->createElementNS('http://docbook.org/ns/docbook', 'title');
+        $title->textContent = 'New Constants';
+        $section->append($title);
+
+        $list = $document->createElementNS('http://docbook.org/ns/docbook', 'simplelist');
+        foreach ($newConstants as $constant) {
+            $member = $document->createElementNS('http://docbook.org/ns/docbook', 'member');
+            $constElement = $document->createElementNS('http://docbook.org/ns/docbook', 'constant');
+            $constElement->textContent = $constant;
+            $member->append($constElement);
+            $list->append("\n  ", $member);
+        }
+        $list->append("\n ");
+        $section->append("\n ", $list, "\n");
+
+        return $section;
+    }
+}

--- a/tests/Generator/MigrationGuideGeneratorTest.php
+++ b/tests/Generator/MigrationGuideGeneratorTest.php
@@ -17,6 +17,7 @@ class MigrationGuideGeneratorTest extends TestCase
         );
 
         $xml = $doc->saveXml($section);
+        self::assertIsString($xml);
         self::assertStringContainsString('<title>New Functions</title>', $xml);
         self::assertStringContainsString('<function>array_any</function>', $xml);
         self::assertStringContainsString('<function>array_all</function>', $xml);
@@ -33,6 +34,7 @@ class MigrationGuideGeneratorTest extends TestCase
         );
 
         $xml = $doc->saveXml($section);
+        self::assertIsString($xml);
         self::assertStringContainsString('<title>Deprecated Functions</title>', $xml);
         self::assertStringContainsString('<function>utf8_encode</function>', $xml);
         self::assertStringContainsString('<function>utf8_decode</function>', $xml);
@@ -47,6 +49,7 @@ class MigrationGuideGeneratorTest extends TestCase
         );
 
         $xml = $doc->saveXml($section);
+        self::assertIsString($xml);
         self::assertStringContainsString('<title>New Constants</title>', $xml);
         self::assertStringContainsString('<constant>PHP_MAJOR_VERSION</constant>', $xml);
         self::assertStringContainsString('<constant>PHP_MINOR_VERSION</constant>', $xml);

--- a/tests/Generator/MigrationGuideGeneratorTest.php
+++ b/tests/Generator/MigrationGuideGeneratorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Generator;
+
+use Dom\XMLDocument;
+use Girgias\StubToDocbook\Generator\MigrationGuideGenerator;
+use PHPUnit\Framework\TestCase;
+
+class MigrationGuideGeneratorTest extends TestCase
+{
+    public function test_generate_new_functions_section(): void
+    {
+        $doc = XMLDocument::createEmpty();
+        $section = MigrationGuideGenerator::generateNewFunctionsSection(
+            $doc,
+            ['array_any', 'array_all', 'json_validate'],
+        );
+
+        $xml = $doc->saveXml($section);
+        self::assertStringContainsString('<title>New Functions</title>', $xml);
+        self::assertStringContainsString('<function>array_any</function>', $xml);
+        self::assertStringContainsString('<function>array_all</function>', $xml);
+        self::assertStringContainsString('<function>json_validate</function>', $xml);
+        self::assertStringContainsString('xml:id="migration.new-functions"', $xml);
+    }
+
+    public function test_generate_deprecated_functions_section(): void
+    {
+        $doc = XMLDocument::createEmpty();
+        $section = MigrationGuideGenerator::generateDeprecatedFunctionsSection(
+            $doc,
+            ['utf8_encode', 'utf8_decode'],
+        );
+
+        $xml = $doc->saveXml($section);
+        self::assertStringContainsString('<title>Deprecated Functions</title>', $xml);
+        self::assertStringContainsString('<function>utf8_encode</function>', $xml);
+        self::assertStringContainsString('<function>utf8_decode</function>', $xml);
+    }
+
+    public function test_generate_new_constants_section(): void
+    {
+        $doc = XMLDocument::createEmpty();
+        $section = MigrationGuideGenerator::generateNewConstantsSection(
+            $doc,
+            ['PHP_MAJOR_VERSION', 'PHP_MINOR_VERSION'],
+        );
+
+        $xml = $doc->saveXml($section);
+        self::assertStringContainsString('<title>New Constants</title>', $xml);
+        self::assertStringContainsString('<constant>PHP_MAJOR_VERSION</constant>', $xml);
+        self::assertStringContainsString('<constant>PHP_MINOR_VERSION</constant>', $xml);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MigrationGuideGenerator` class with sections for new functions, deprecated functions, and new constants
- Generate proper DocBook XML with `<simplelist>`, `<function>`, and `<constant>` elements
- Add tests for all section types

Closes #50