### PR TITLE
Update existing constants documentation from stubs

### DIFF
--- a/src/Updater/ConstantDocUpdater.php
+++ b/src/Updater/ConstantDocUpdater.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Girgias\StubToDocbook\Updater;
+
+use Dom\Element;
+use Dom\XMLDocument;
+use Girgias\StubToDocbook\MetaData\ConstantMetaData;
+
+final class ConstantDocUpdater
+{
+    /**
+     * Update a constant's type in a <varlistentry> element.
+     *
+     * @return bool Whether the element was modified
+     */
+    public static function updateTypeInVarListEntry(Element $entry, ConstantMetaData $stubConstant): bool
+    {
+        $terms = $entry->getElementsByTagName('term');
+        if ($terms->length === 0) {
+            return false;
+        }
+
+        $term = $terms[0];
+        $existingTypes = $term->getElementsByTagName('type');
+        $newType = $stubConstant->type;
+
+        if ($newType === null) {
+            return false;
+        }
+
+        $doc = $entry->ownerDocument;
+        $ns = $entry->namespaceURI ?? '';
+        $newTypeElement = $doc->createElementNS($ns, 'type');
+        $newTypeElement->textContent = $newType->name;
+
+        if ($existingTypes->length > 0) {
+            // Replace existing type
+            $oldType = $existingTypes[0];
+            $oldType->parentNode->replaceChild($newTypeElement, $oldType);
+        } else {
+            // Add type before or after the constant tag
+            $constantTags = $term->getElementsByTagName('constant');
+            if ($constantTags->length > 0) {
+                $constantTag = $constantTags[0];
+                // Insert type and parentheses after constant
+                $constantTag->after("\n    (", $newTypeElement, ")");
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Update a constant's type in a table <row> element.
+     *
+     * @return bool Whether the element was modified
+     */
+    public static function updateTypeInTableRow(Element $row, ConstantMetaData $stubConstant, int $typeColumnIndex = 1): bool
+    {
+        $entries = $row->getElementsByTagName('entry');
+        if ($entries->length <= $typeColumnIndex) {
+            return false;
+        }
+
+        $newType = $stubConstant->type;
+        if ($newType === null) {
+            return false;
+        }
+
+        $typeEntry = $entries[$typeColumnIndex];
+        $existingTypes = $typeEntry->getElementsByTagName('type');
+
+        $doc = $row->ownerDocument;
+        $ns = $row->namespaceURI ?? '';
+        $newTypeElement = $doc->createElementNS($ns, 'type');
+        $newTypeElement->textContent = $newType->name;
+
+        if ($existingTypes->length > 0) {
+            $oldType = $existingTypes[0];
+            $oldType->parentNode->replaceChild($newTypeElement, $oldType);
+        } else {
+            // Clear and add type
+            $typeEntry->textContent = '';
+            $typeEntry->append($newTypeElement);
+        }
+
+        return true;
+    }
+}

--- a/src/Updater/ConstantDocUpdater.php
+++ b/src/Updater/ConstantDocUpdater.php
@@ -3,7 +3,6 @@
 namespace Girgias\StubToDocbook\Updater;
 
 use Dom\Element;
-use Dom\XMLDocument;
 use Girgias\StubToDocbook\MetaData\ConstantMetaData;
 
 final class ConstantDocUpdater

--- a/tests/Updater/ConstantDocUpdaterTest.php
+++ b/tests/Updater/ConstantDocUpdaterTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Updater;
+
+use Dom\XMLDocument;
+use Girgias\StubToDocbook\MetaData\ConstantMetaData;
+use Girgias\StubToDocbook\Types\SingleType;
+use Girgias\StubToDocbook\Updater\ConstantDocUpdater;
+use PHPUnit\Framework\TestCase;
+
+class ConstantDocUpdaterTest extends TestCase
+{
+    public function test_update_type_in_varlistentry(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<varlistentry xml:id="constant.test" xmlns="http://docbook.org/ns/docbook">
+ <term>
+  <constant>TEST_CONST</constant>
+  (<type>string</type>)
+ </term>
+ <listitem><simpara>Description</simpara></listitem>
+</varlistentry>
+XML;
+
+        $doc = XMLDocument::createFromString($xml);
+        $entry = $doc->firstElementChild;
+
+        $stubConstant = new ConstantMetaData(
+            'TEST_CONST',
+            new SingleType('int'),
+            'test',
+            'constant.test',
+        );
+
+        $result = ConstantDocUpdater::updateTypeInVarListEntry($entry, $stubConstant);
+        self::assertTrue($result);
+
+        $output = $doc->saveXml($entry);
+        self::assertStringContainsString('<type>int</type>', $output);
+        self::assertStringNotContainsString('<type>string</type>', $output);
+    }
+
+    public function test_update_type_in_table_row(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<row xmlns="http://docbook.org/ns/docbook">
+ <entry><constant>TABLE_CONST</constant></entry>
+ <entry><type>string</type></entry>
+ <entry>Description</entry>
+</row>
+XML;
+
+        $doc = XMLDocument::createFromString($xml);
+        $row = $doc->firstElementChild;
+
+        $stubConstant = new ConstantMetaData(
+            'TABLE_CONST',
+            new SingleType('float'),
+            'test',
+            null,
+        );
+
+        $result = ConstantDocUpdater::updateTypeInTableRow($row, $stubConstant);
+        self::assertTrue($result);
+
+        $output = $doc->saveXml($row);
+        self::assertStringContainsString('<type>float</type>', $output);
+        self::assertStringNotContainsString('<type>string</type>', $output);
+    }
+
+    public function test_no_update_when_stub_has_no_type(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<varlistentry xmlns="http://docbook.org/ns/docbook">
+ <term><constant>NO_TYPE</constant></term>
+ <listitem><simpara>Description</simpara></listitem>
+</varlistentry>
+XML;
+
+        $doc = XMLDocument::createFromString($xml);
+        $entry = $doc->firstElementChild;
+
+        $stubConstant = new ConstantMetaData(
+            'NO_TYPE',
+            null,
+            'test',
+            null,
+        );
+
+        $result = ConstantDocUpdater::updateTypeInVarListEntry($entry, $stubConstant);
+        self::assertFalse($result);
+    }
+}

--- a/tests/Updater/ConstantDocUpdaterTest.php
+++ b/tests/Updater/ConstantDocUpdaterTest.php
@@ -37,6 +37,7 @@ XML;
         self::assertTrue($result);
 
         $output = $doc->saveXml($entry);
+        self::assertIsString($output);
         self::assertStringContainsString('<type>int</type>', $output);
         self::assertStringNotContainsString('<type>string</type>', $output);
     }
@@ -66,6 +67,7 @@ XML;
         self::assertTrue($result);
 
         $output = $doc->saveXml($row);
+        self::assertIsString($output);
         self::assertStringContainsString('<type>float</type>', $output);
         self::assertStringNotContainsString('<type>string</type>', $output);
     }


### PR DESCRIPTION
## Summary
- Add `ConstantDocUpdater` class for updating constant type information in DocBook XML
- Support updating types in `<varlistentry>` format (replaces existing or adds new type)
- Support updating types in `<table>` row format
- Preserve existing descriptions and formatting
- Add tests for varlistentry, table row, and null type handling

Closes #45