### PR TITLE
Update existing functions documentation from stubs

### DIFF
--- a/src/Updater/FunctionDocUpdater.php
+++ b/src/Updater/FunctionDocUpdater.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Girgias\StubToDocbook\Updater;
+
+use Dom\Element;
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
+use Girgias\StubToDocbook\MetaData\Functions\ParameterMetaData;
+
+final class FunctionDocUpdater
+{
+    /**
+     * Update the return type in a <methodsynopsis> element.
+     *
+     * @return bool Whether the element was modified
+     */
+    public static function updateReturnType(Element $methodSynopsis, FunctionMetaData $stubFunction): bool
+    {
+        $doc = $methodSynopsis->ownerDocument;
+        $ns = $methodSynopsis->namespaceURI ?? '';
+
+        // Find existing type element
+        $existingTypes = [];
+        foreach ($methodSynopsis->childNodes as $child) {
+            if ($child instanceof Element && $child->tagName === 'type') {
+                $existingTypes[] = $child;
+                break;
+            }
+        }
+
+        if (empty($existingTypes)) {
+            return false;
+        }
+
+        $oldType = $existingTypes[0];
+        $newTypeElement = $doc->createElementNS($ns, 'type');
+        $newTypeElement->textContent = $stubFunction->returnType->toXml();
+        // For simple types, just set the name
+        if (preg_match('/<type>([^<]+)<\/type>/', $stubFunction->returnType->toXml(), $m)) {
+            $newTypeElement->textContent = $m[1];
+        }
+        $oldType->parentNode->replaceChild($newTypeElement, $oldType);
+        return true;
+    }
+
+    /**
+     * Update a parameter's type in a <methodparam> element.
+     *
+     * @return bool Whether the element was modified
+     */
+    public static function updateParameterType(Element $methodParam, ParameterMetaData $stubParam): bool
+    {
+        $doc = $methodParam->ownerDocument;
+        $ns = $methodParam->namespaceURI ?? '';
+
+        $typeTags = $methodParam->getElementsByTagName('type');
+        if ($typeTags->length === 0) {
+            return false;
+        }
+
+        $oldType = $typeTags[0];
+        $newTypeElement = $doc->createElementNS($ns, 'type');
+        if (preg_match('/<type>([^<]+)<\/type>/', $stubParam->type->toXml(), $m)) {
+            $newTypeElement->textContent = $m[1];
+        }
+        $oldType->parentNode->replaceChild($newTypeElement, $oldType);
+
+        return true;
+    }
+
+    /**
+     * Update optional status of a <methodparam> element.
+     *
+     * @return bool Whether the element was modified
+     */
+    public static function updateParameterOptional(Element $methodParam, ParameterMetaData $stubParam): bool
+    {
+        $currentChoice = $methodParam->getAttribute('choice');
+        $shouldBeOptional = $stubParam->isOptional;
+
+        if ($shouldBeOptional && $currentChoice !== 'opt') {
+            $methodParam->setAttribute('choice', 'opt');
+            return true;
+        }
+
+        if (!$shouldBeOptional && $currentChoice === 'opt') {
+            $methodParam->removeAttribute('choice');
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/Updater/FunctionDocUpdaterTest.php
+++ b/tests/Updater/FunctionDocUpdaterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Updater;
+
+use Dom\XMLDocument;
+use Girgias\StubToDocbook\MetaData\Functions\FunctionMetaData;
+use Girgias\StubToDocbook\MetaData\Functions\ParameterMetaData;
+use Girgias\StubToDocbook\Types\SingleType;
+use Girgias\StubToDocbook\Updater\FunctionDocUpdater;
+use PHPUnit\Framework\TestCase;
+
+class FunctionDocUpdaterTest extends TestCase
+{
+    public function test_update_return_type(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<methodsynopsis xmlns="http://docbook.org/ns/docbook">
+ <type>string</type><methodname>test_func</methodname>
+ <void/>
+</methodsynopsis>
+XML;
+
+        $doc = XMLDocument::createFromString($xml);
+        $synopsis = $doc->firstElementChild;
+
+        $stubFunction = new FunctionMetaData(
+            'test_func',
+            [],
+            new SingleType('int'),
+            'test',
+        );
+
+        $result = FunctionDocUpdater::updateReturnType($synopsis, $stubFunction);
+        self::assertTrue($result);
+
+        $output = $doc->saveXml($synopsis);
+        self::assertIsString($output);
+        self::assertStringContainsString('<type>int</type>', $output);
+    }
+
+    public function test_update_parameter_type(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<methodparam xmlns="http://docbook.org/ns/docbook">
+ <type>string</type><parameter>input</parameter>
+</methodparam>
+XML;
+
+        $doc = XMLDocument::createFromString($xml);
+        $param = $doc->firstElementChild;
+
+        $stubParam = new ParameterMetaData(
+            'input',
+            1,
+            new SingleType('int'),
+        );
+
+        $result = FunctionDocUpdater::updateParameterType($param, $stubParam);
+        self::assertTrue($result);
+
+        $output = $doc->saveXml($param);
+        self::assertIsString($output);
+        self::assertStringContainsString('<type>int</type>', $output);
+    }
+
+    public function test_update_parameter_optional(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<methodparam xmlns="http://docbook.org/ns/docbook">
+ <type>int</type><parameter>flags</parameter>
+</methodparam>
+XML;
+
+        $doc = XMLDocument::createFromString($xml);
+        $param = $doc->firstElementChild;
+
+        $stubParam = new ParameterMetaData(
+            'flags',
+            1,
+            new SingleType('int'),
+            isOptional: true,
+        );
+
+        $result = FunctionDocUpdater::updateParameterOptional($param, $stubParam);
+        self::assertTrue($result);
+        self::assertSame('opt', $param->getAttribute('choice'));
+
+        // Already optional - no change
+        $result2 = FunctionDocUpdater::updateParameterOptional($param, $stubParam);
+        self::assertFalse($result2);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `FunctionDocUpdater` class for updating function signatures in DocBook XML
- `updateReturnType()` replaces the return type in `<methodsynopsis>`
- `updateParameterType()` replaces a parameter's type in `<methodparam>`
- `updateParameterOptional()` sets or removes `choice="opt"` attribute
- Add tests for all update methods

Closes #46