### PR TITLE
Add class, enum, and attribute documentation updater

### DIFF
--- a/src/Updater/ClassDocUpdater.php
+++ b/src/Updater/ClassDocUpdater.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Girgias\StubToDocbook\Updater;
+
+use Dom\Element;
+
+final class ClassDocUpdater
+{
+    /**
+     * Update a property's type in a <fieldsynopsis> element.
+     *
+     * @return bool Whether the element was modified
+     */
+    public static function updatePropertyType(Element $fieldSynopsis, string $newTypeName): bool
+    {
+        $doc = $fieldSynopsis->ownerDocument;
+        $ns = $fieldSynopsis->namespaceURI ?? '';
+
+        $typeTags = $fieldSynopsis->getElementsByTagName('type');
+        $newTypeElement = $doc->createElementNS($ns, 'type');
+        $newTypeElement->textContent = $newTypeName;
+
+        if ($typeTags->length > 0) {
+            $oldType = $typeTags[0];
+            $oldType->parentNode->replaceChild($newTypeElement, $oldType);
+            return true;
+        }
+
+        // Add type before varname
+        $varnameTags = $fieldSynopsis->getElementsByTagName('varname');
+        if ($varnameTags->length > 0) {
+            $varnameTags[0]->before($newTypeElement);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Update a class constant's type in a <fieldsynopsis> element.
+     *
+     * @return bool Whether the element was modified
+     */
+    public static function updateConstantType(Element $fieldSynopsis, string $newTypeName): bool
+    {
+        $doc = $fieldSynopsis->ownerDocument;
+        $ns = $fieldSynopsis->namespaceURI ?? '';
+
+        $typeTags = $fieldSynopsis->getElementsByTagName('type');
+        $newTypeElement = $doc->createElementNS($ns, 'type');
+        $newTypeElement->textContent = $newTypeName;
+
+        if ($typeTags->length > 0) {
+            $oldType = $typeTags[0];
+            $oldType->parentNode->replaceChild($newTypeElement, $oldType);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Update visibility modifier in a <fieldsynopsis> or <methodsynopsis> element.
+     *
+     * @return bool Whether the element was modified
+     */
+    public static function updateVisibility(Element $element, string $newVisibility): bool
+    {
+        $modifiers = $element->getElementsByTagName('modifier');
+        foreach ($modifiers as $modifier) {
+            $text = $modifier->textContent;
+            if (in_array($text, ['public', 'protected', 'private'], true)) {
+                if ($text !== $newVisibility) {
+                    $modifier->textContent = $newVisibility;
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Updater/ClassDocUpdaterTest.php
+++ b/tests/Updater/ClassDocUpdaterTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Updater;
+
+use Dom\XMLDocument;
+use Girgias\StubToDocbook\Updater\ClassDocUpdater;
+use PHPUnit\Framework\TestCase;
+
+class ClassDocUpdaterTest extends TestCase
+{
+    public function test_update_property_type(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<fieldsynopsis xmlns="http://docbook.org/ns/docbook">
+ <modifier>public</modifier>
+ <type>string</type>
+ <varname>name</varname>
+</fieldsynopsis>
+XML;
+
+        $doc = XMLDocument::createFromString($xml);
+        $field = $doc->firstElementChild;
+
+        $result = ClassDocUpdater::updatePropertyType($field, 'int');
+        self::assertTrue($result);
+
+        $output = $doc->saveXml($field);
+        self::assertIsString($output);
+        self::assertStringContainsString('<type>int</type>', $output);
+        self::assertStringNotContainsString('<type>string</type>', $output);
+    }
+
+    public function test_update_constant_type(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<fieldsynopsis xmlns="http://docbook.org/ns/docbook">
+ <modifier>public</modifier>
+ <modifier>const</modifier>
+ <type>string</type>
+ <constant>MyClass::CONST_A</constant>
+</fieldsynopsis>
+XML;
+
+        $doc = XMLDocument::createFromString($xml);
+        $field = $doc->firstElementChild;
+
+        $result = ClassDocUpdater::updateConstantType($field, 'int');
+        self::assertTrue($result);
+
+        $output = $doc->saveXml($field);
+        self::assertIsString($output);
+        self::assertStringContainsString('<type>int</type>', $output);
+    }
+
+    public function test_update_visibility(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<fieldsynopsis xmlns="http://docbook.org/ns/docbook">
+ <modifier>public</modifier>
+ <type>string</type>
+ <varname>name</varname>
+</fieldsynopsis>
+XML;
+
+        $doc = XMLDocument::createFromString($xml);
+        $field = $doc->firstElementChild;
+
+        $result = ClassDocUpdater::updateVisibility($field, 'protected');
+        self::assertTrue($result);
+
+        $output = $doc->saveXml($field);
+        self::assertIsString($output);
+        self::assertStringContainsString('<modifier>protected</modifier>', $output);
+
+        // No change when already correct
+        $result2 = ClassDocUpdater::updateVisibility($field, 'protected');
+        self::assertFalse($result2);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ClassDocUpdater` class for updating types and visibility in DocBook XML
- `updatePropertyType()` replaces property type in `<fieldsynopsis>` elements
- `updateConstantType()` replaces class constant type in `<fieldsynopsis>` elements
- `updateVisibility()` updates visibility modifier (public/protected/private)
- Works for classes, enums, and attributes (all use `<fieldsynopsis>`)
- Add tests for all update methods

Closes #47
Closes #48
Closes #49